### PR TITLE
Fix compilation on Ubuntu 22 

### DIFF
--- a/src/utils/semantic_segmentation_helpers.hpp
+++ b/src/utils/semantic_segmentation_helpers.hpp
@@ -6,6 +6,7 @@
 //
 
 #pragma once
+#include <limits>
 
 #include <ie_blob.h>
 

--- a/src/vpux_utils/src/plugin/profiling_parser.cpp
+++ b/src/vpux_utils/src/plugin/profiling_parser.cpp
@@ -1204,7 +1204,7 @@ ClusterTaskArray groupClusterTasks(const RawProfilingRecords& rawTasks) {
 
     // Grouping of variants into one invariant
     std::multimap<std::pair<std::string, size_t>, RawProfilingRecordPtr> groupedClustersInfo;
-    for (const auto task : rawTasks) {
+    for (const auto &task : rawTasks) {
         const auto clusterId = std::dynamic_pointer_cast<ClusteredAndTiledMixin>(task)->getClusterId();
         const auto key = std::make_pair(task->getRawName(), clusterId);
         groupedClustersInfo.insert(std::make_pair(key, task));
@@ -1233,7 +1233,7 @@ RawProfilingRecords groupTasks(const ClusterTaskArray& clusterInfoTasks) {
 
     // Grouping of invariants to one NCE Task
     std::multimap<std::string, std::shared_ptr<ArrayRecord>> groupedDPUTasksInfo;
-    for (const auto task : clusterInfoTasks) {
+    for (const auto &task : clusterInfoTasks) {
         groupedDPUTasksInfo.insert(std::make_pair(task->getRawName(), task));
     }
     auto it = groupedDPUTasksInfo.cbegin();


### PR DESCRIPTION
## Summary

Fix errors due to more strict check in latest g++ compiler on Ubuntu 22.04


## Target Platform For Release Notes (Mandatory)

Aids the generation of release notes

- [ ] VPUX3011
- [ ] VPUX3011
- [ ] VPUX3110
- [ ] VPUX37XX
- [ ] NONE (Not included in release notes)

## Classification of this Pull Request

- [ ] Maintenance
- [ ] BUG
- [ ] Feature

## Related PRs

(Please add links to related PRs (if you have such PRs) and a small note why you depend on it)

* <pr-link> (<description>)

## Related tickets

(Please list tickets which the PR closes if you have any)

* E#####

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
