### PR TITLE
Fix nlohmann_json include on Ubuntu22

### DIFF
--- a/src/VPUXCompilerL0/CMakeLists.txt
+++ b/src/VPUXCompilerL0/CMakeLists.txt
@@ -75,9 +75,22 @@ endif()
 target_include_directories(${FUNCTIONAL_TARGET}
     PUBLIC
         "${CMAKE_SOURCE_DIR}/src/core/include"
-    PRIVATE
-        $<TARGET_PROPERTY:IE::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
+if(TARGET IE::nlohmann_json)
+    target_include_directories(${FUNCTIONAL_TARGET}
+        PRIVATE
+        $<TARGET_PROPERTY:IE::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+else()
+    find_package(nlohmann_json 3.9.0 QUIET)
+    if(nlohmann_json_FOUND)
+        target_include_directories(${FUNCTIONAL_TARGET}
+            PRIVATE
+            $<TARGET_PROPERTY:nlohmann_json::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+    else()
+        message(FATAL_ERROR "Failed to find system nlohmann_json in OpenVINO Developer Package and system libraries")
+    endif()
+endif()
 
 link_system_libraries(${FUNCTIONAL_TARGET}
     PUBLIC

--- a/src/vpux_compiler/CMakeLists.txt
+++ b/src/vpux_compiler/CMakeLists.txt
@@ -501,8 +501,22 @@ target_include_directories(${OBJ_TARGET_NAME}
     PRIVATE
         ${BITCOMPACTOR_INCLUDES}
         $<TARGET_PROPERTY:huffman_codec,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:IE::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
+if(TARGET IE::nlohmann_json)
+    target_include_directories(${OBJ_TARGET_NAME}
+        PRIVATE
+        $<TARGET_PROPERTY:IE::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+else()
+    find_package(nlohmann_json 3.9.0 QUIET)
+    if(nlohmann_json_FOUND)
+        target_include_directories(${OBJ_TARGET_NAME}
+            PRIVATE
+            $<TARGET_PROPERTY:nlohmann_json::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+    else()
+        message(FATAL_ERROR "Failed to find system nlohmann_json in OpenVINO Developer Package and system libraries")
+    endif()
+endif()
 
 target_include_directories(${OBJ_TARGET_NAME}
     SYSTEM PUBLIC


### PR DESCRIPTION
## Summary

The reason is https://github.com/openvinotoolkit/openvino/blob/releases/2023/0/thirdparty/CMakeLists.txt#L604 
On Ubuntu20 we have 3.7.3 in apt-get, so OV add and export its own target
On Ubuntu22 we have 3.10.5 in apt-get, so OV ignores its own nlohmann_json and doesn't export IE::nlohmann_json

## Target Platform For Release Notes (Mandatory)

Aids the generation of release notes

- [ ] VPUX3011
- [ ] VPUX3011
- [ ] VPUX3110
- [ ] VPUX37XX
- [ ] NONE (Not included in release notes)

## Classification of this Pull Request

- [ ] Maintenance
- [x] BUG
- [ ] Feature

## Related PRs

(Please add links to related PRs (if you have such PRs) and a small note why you depend on it)

* <pr-link> (<description>)

## Related tickets

(Please list tickets which the PR closes if you have any)

* E#####

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
