### PR TITLE
Bump scipy up to 1.10.0

### DIFF
--- a/src/vpux_translate_utils/src/hwtest/requirements.txt
+++ b/src/vpux_translate_utils/src/hwtest/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.19.5
-scipy~=1.9.0
+scipy~=1.10.0
 pandas~=1.4.3
 openpyxl~=3.0.10
 bitarray~=2.7.3


### PR DESCRIPTION
## Summary

A refcounting issue which leads to potential memory leak was discovered in scipy commit 8627df31ab in Py_FindObjects() function.

## Target Platform For Release Notes (Mandatory)

Aids the generation of release notes

- [ ] VPUX3011
- [ ] VPUX3011
- [x] VPUX3110
- [x] VPUX37XX
- [ ] NONE (Not included in release notes)

## Classification of this Pull Request

- [ ] Maintenance
- [x] BUG
- [ ] Feature

## Related PRs

(Please add links to related PRs (if you have such PRs) and a small note why you depend on it)

* <pr-link> (<description>)

## Related tickets

(Please list tickets which the PR closes if you have any)

* E#####

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
