### PR TITLE
Upstreaming plugin repository (2024 Q1) - Fix target_include_directories issue

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -29,37 +29,13 @@ set(BUILD_SHARED_LIBS OFF)
 #
 # LLVM/MLIR
 #
-
-set(LLVM_ENABLE_WARNINGS OFF CACHE BOOL "")
-set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "" FORCE)
-set(LLVM_ENABLE_RTTI ON CACHE BOOL "" FORCE)
-set(LLVM_ENABLE_EH ON CACHE BOOL "" FORCE)
-set(LLVM_ENABLE_BACKTRACES OFF CACHE BOOL "" FORCE)
-set(LLVM_ENABLE_CRASH_OVERRIDES OFF CACHE BOOL "" FORCE)
-set(LLVM_ENABLE_PROJECTS "mlir" CACHE STRING "" FORCE)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR ENABLE_DEVELOPER_BUILD)
-    set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "" FORCE)
-else()
-    set(LLVM_ENABLE_ASSERTIONS OFF CACHE BOOL "" FORCE)
+if(NOT ENABLE_PREBUILT_LLVM_MLIR_LIBS)
+    set_llvm_flags()
+    add_subdirectory(llvm-project/llvm EXCLUDE_FROM_ALL)
+    set(MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/llvm-project/mlir/include")
+    set(MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/llvm-project/llvm/tools/mlir/include")
+    include_directories(SYSTEM ${MLIR_SOURCE_DIR} ${MLIR_BINARY_DIR})
 endif()
-set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
-set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
-set(LLVM_TARGETS_TO_BUILD "host" CACHE STRING "" FORCE)
-set(CROSS_TOOLCHAIN_FLAGS_ "" CACHE STRING "" FORCE)
-set(CROSS_TOOLCHAIN_FLAGS_NATIVE "" CACHE STRING "" FORCE)
-set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "" FORCE)
-# we do not use examples and having it enabled
-# makes cmake complains about long path on Windows
-set(LLVM_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "" FORCE)
-
-add_subdirectory(llvm-project/llvm EXCLUDE_FROM_ALL)
-
-set(MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/llvm-project/mlir/include")
-set(MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/llvm-project/llvm/tools/mlir/include")
-include_directories(SYSTEM
-    ${MLIR_SOURCE_DIR}
-    ${MLIR_BINARY_DIR})
 
 #
 # flatbuffers
@@ -90,15 +66,25 @@ vpux_add_native_tool(flatc "${CMAKE_CURRENT_SOURCE_DIR}/flatbuffers"
 )
 
 #
-# vpux_elf
+# npu_elf
 #
 
-set(VPUX_ELF_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/elf")
-set(VPUX_ELF_SOURCE_DIR "${VPUX_ELF_SOURCE_DIR}" PARENT_SCOPE)
-message("VPUX_ELF_SOURCE_DIR : ${VPUX_ELF_SOURCE_DIR}")
+if (ENABLE_NPU_MONO)
+    if (NOT TARGET npu_elf)
+        message(FATAL_ERROR "elf/vpux_elf target must exist since ENABLE_NPU_MONO is ON")
+    endif()
+    # TODO remove:
+    # `src/vpux_compiler/include/vpux/compiler/dialect/VPU37XX/api`
+    # after integration finishes
+else()
+    # Legacy no-monorepo scenario
+    add_subdirectory(elf/vpux_elf)
+    target_include_directories(npu_elf PRIVATE
+        "${IE_MAIN_VPUX_PLUGIN_SOURCE_DIR}/src/vpux_compiler/include/vpux/compiler/dialect/VPU37XX/firmware_headers/details")
 
-add_subdirectory(${VPUX_ELF_SOURCE_DIR}/vpux_elf)
-target_include_directories(vpux_elf PRIVATE "${IE_MAIN_VPUX_PLUGIN_SOURCE_DIR}/src/vpux_compiler/include/vpux/compiler/dialect/VPU37XX")
+    target_include_directories(vpux_elf PRIVATE
+        "${IE_MAIN_VPUX_PLUGIN_SOURCE_DIR}/src/vpux_compiler/include/vpux/compiler/dialect/VPU37XX/firmware_headers/details")
+endif()
 
 #
 # zeroApi


### PR DESCRIPTION
## Summary
Upstreaming plugin repository (2024 Q1) - Fix target_include_directories issue

```
fatal error: api/vpu_nnrt_api_37xx.h: No such file or directory
```

## Target Platform For Release Notes (Mandatory)

Aids the generation of release notes

- [ ] VPUX30XX
- [ ] VPUX31XX
- [x] VPUX37XX
- [ ] NONE (Not included in release notes)

## Classification of this Pull Request

- [x] Maintenance
- [ ] BUG
- [ ] Feature

## Related PRs

* [PR-xxx](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/xxx) description

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
