### PR TITLE
Disable building background folding components when TBB is missing

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -96,6 +96,14 @@ if(ENABLE_HUFFMAN_CODEC)
     add_definitions(-DENABLE_HUFFMAN_CODEC)
 endif()
 
+if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO")
+    set(TBB_AVAILABLE ON)
+endif()
+ov_dependent_option(ENABLE_BACKGROUND_FOLDING "Enable constant folding in background" ON "TBB_AVAILABLE" OFF)
+if(ENABLE_BACKGROUND_FOLDING)
+    add_definitions(-DBACKGROUND_FOLDING_ENABLED)
+endif()
+
 ie_option(ENABLE_SOURCE_PACKAGE "Enable generation of source code package" OFF)
 
 ie_option(ENABLE_VPUX_DOCS "Documentation for VPUX plugin" OFF)

--- a/src/vpux_compiler/include/vpux/compiler/dialect/const/utils/constant_folding_cache.hpp
+++ b/src/vpux_compiler/include/vpux/compiler/dialect/const/utils/constant_folding_cache.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#ifdef BACKGROUND_FOLDING_ENABLED
+
 #include "vpux/compiler/dialect/const/attributes/content.hpp"
 #include "vpux/compiler/dialect/const/utils/content.hpp"
 
@@ -254,3 +256,5 @@ private:
 
 }  // namespace Const
 }  // namespace vpux
+
+#endif

--- a/src/vpux_compiler/include/vpux/compiler/dialect/const/utils/constant_folding_in_background.hpp
+++ b/src/vpux_compiler/include/vpux/compiler/dialect/const/utils/constant_folding_in_background.hpp
@@ -5,7 +5,10 @@
 
 #pragma once
 
+#ifdef BACKGROUND_FOLDING_ENABLED
+
 #include "vpux/utils/core/array_ref.hpp"
+#include "vpux/utils/core/logger.hpp"
 #include "vpux/utils/core/small_vector.hpp"
 
 #include <llvm/Support/ThreadPool.h>
@@ -18,7 +21,9 @@ SmallVector<std::shared_future<void>> initBackgroundConstantFoldingThreads(mlir:
                                                                            bool collectStatistics);
 
 void stopBackgroundConstantFoldingThreads(mlir::MLIRContext* ctx, ArrayRef<std::shared_future<void>> foldingThreads,
-                                          bool collectStatistics);
+                                          bool collectStatistics, Logger log = Logger::global());
 
 }  // namespace Const
 }  // namespace vpux
+
+#endif

--- a/src/vpux_compiler/src/dialect/const/attributes/content.cpp
+++ b/src/vpux_compiler/src/dialect/const/attributes/content.cpp
@@ -167,6 +167,7 @@ Const::Content wrapBaseContent(mlir::ElementsAttr baseContent) {
 Const::Content vpux::Const::ContentAttr::fold(bool bypassCache) const {
     auto baseContent = getBaseContent();
 
+#ifdef BACKGROUND_FOLDING_ENABLED
     if (!bypassCache) {
         auto& cacheManager = Const::ConstantFoldingCacheManager::getInstance();
         auto ctx = baseContent.getContext();
@@ -178,6 +179,9 @@ Const::Content vpux::Const::ContentAttr::fold(bool bypassCache) const {
             }
         }
     }
+#else
+    VPUX_UNUSED(bypassCache);
+#endif
 
     auto res = wrapBaseContent(baseContent);
 
@@ -320,12 +324,14 @@ Const::ContentAttr Const::ContentAttr::addTransformation(Const::ContentAttr inpu
 
     auto newContentAttr = Const::ContentAttr::get(baseContent, ArrayRef(transformations));
 
+#ifdef BACKGROUND_FOLDING_ENABLED
     auto& cacheManager = Const::ConstantFoldingCacheManager::getInstance();
     auto ctx = newContentAttr.getContext();
     if (cacheManager.contains(ctx)) {
         auto& cache = cacheManager.get(ctx);
         cache.enqueueRequest(Const::FoldingRequest{newContentAttr, newTransformation});
     }
+#endif
 
     return newContentAttr;
 }

--- a/src/vpux_compiler/src/dialect/const/utils/constant_folding_cache.cpp
+++ b/src/vpux_compiler/src/dialect/const/utils/constant_folding_cache.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache 2.0
 //
 
+#ifdef BACKGROUND_FOLDING_ENABLED
+
 #include "vpux/compiler/dialect/const/utils/constant_folding_cache.hpp"
 
 using namespace vpux;
@@ -196,3 +198,5 @@ Const::ConstantFoldingCache& Const::ConstantFoldingCacheManager::get(mlir::MLIRC
     }
     VPUX_THROW("Unable to find cache for {0}", ctx);
 }
+
+#endif

--- a/src/vpux_compiler/src/dialect/const/utils/constant_folding_in_background.cpp
+++ b/src/vpux_compiler/src/dialect/const/utils/constant_folding_in_background.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache 2.0
 //
 
+#ifdef BACKGROUND_FOLDING_ENABLED
+
 #include "vpux/compiler/dialect/const/utils/constant_folding_in_background.hpp"
 #include "vpux/compiler/dialect/const/utils/constant_folding_cache.hpp"
 
@@ -117,7 +119,7 @@ SmallVector<std::shared_future<void>> Const::initBackgroundConstantFoldingThread
 
 void Const::stopBackgroundConstantFoldingThreads(mlir::MLIRContext* ctx,
                                                  ArrayRef<std::shared_future<void>> foldingThreads,
-                                                 bool collectStatistics) {
+                                                 bool collectStatistics, Logger log) {
     auto& cacheManager = Const::ConstantFoldingCacheManager::getInstance();
     auto& cache = cacheManager.get(ctx);
 
@@ -132,7 +134,7 @@ void Const::stopBackgroundConstantFoldingThreads(mlir::MLIRContext* ctx,
     }
 
     if (collectStatistics) {
-        Logger log("constant-folding-in-background", LogLevel::Info);
+        log.setName("constant-folding-in-background");
         auto& statistics = cacheManager.get(ctx).getStatistics();
         log.trace("Cache statistics");
         log.nest().trace("number of cache hits:                       {0}", statistics.numCacheHits);
@@ -148,3 +150,5 @@ void Const::stopBackgroundConstantFoldingThreads(mlir::MLIRContext* ctx,
 
     cacheManager.removeCache(ctx);
 }
+
+#endif

--- a/tests/unit/vpux_compiler/dialect/const/constant_folding_in_background_tests.cpp
+++ b/tests/unit/vpux_compiler/dialect/const/constant_folding_in_background_tests.cpp
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache 2.0
 //
 
-#include "common/utils.hpp"
+#ifdef BACKGROUND_FOLDING_ENABLED
+
 #include "vpux/compiler/dialect/const/utils/constant_folding_cache.hpp"
 #include "vpux/compiler/dialect/const/utils/constant_folding_in_background.hpp"
+
+#include "common/utils.hpp"
 #include "vpux/compiler/init.hpp"
 
 #include <mlir/IR/AsmState.h>
@@ -128,3 +131,5 @@ TEST_P(ConstantFoldingInBackground, MultipleCompilations) {
 std::vector<size_t> numThreads = {1, 2, 3, 4, 5};
 
 INSTANTIATE_TEST_SUITE_P(MLIRThreading, ConstantFoldingInBackground, testing::ValuesIn(numThreads));
+
+#endif


### PR DESCRIPTION
## Summary

(Cherry-picked fix)

OV can be built without TBB (e.g. when setting `-DTHREADING=SEQ` during build). This is the scenario encountered for ChromeOS. When the plugin is being build with OV in this case, the build fails as it has a dependency on TBB for constant folding in background.

To resolve this build dependency, the components of constant folding in background are disabled from being built when `OV_THREAD` is not set to `TBB` or `TBB_AUTO`. As a result, background folding is not an available feature for this case.

## Target Platform For Release Notes (Mandatory)

Aids the generation of release notes

- [ ] VPUX30XX
- [ ] VPUX31XX
- [ ] VPUX37XX
- [x] NONE (Not included in release notes)

## Classification of this Pull Request

- [ ] Maintenance
- [x] BUG
- [ ] Feature

## Related PRs

* [PR-xxx](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/xxx) description

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
