### PR TITLE
[Ubuntu24.04] llvm-project in vpux_plugin fails to compile

### DIFF
--- a/src/vpux_compiler/src/conversion/passes/VPUIP2VPUMI40XX/convert_VPUIP_to_VPUMI40XX.cpp
+++ b/src/vpux_compiler/src/conversion/passes/VPUIP2VPUMI40XX/convert_VPUIP_to_VPUMI40XX.cpp
@@ -746,6 +746,8 @@ private:
         return std::pair<mlir::Value, mlir::Value>(kernelRangeOp.getResult(), kernelInvocationOp.getResult());
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     void replaceVPURTTaskOpWithKernelOps(mlir::MLIRContext* ctx, mlir::ModuleOp& moduleOp, mlir::func::FuncOp& funcOp,
                                          Logger& _log) {
         _log.info("VPUIP_VPUMI40XX pass: replaceVPURTTaskOpWithKernelOps()");
@@ -1035,6 +1037,7 @@ private:
             }
         }
     }
+#pragma GCC diagnostic pop
 
     void setBarrierIndexValues(mlir::MLIRContext* ctx, mlir::func::FuncOp& funcOp, Logger _log) {
         auto barrierCount = 0;

--- a/src/vpux_compiler/src/dialect/VPU/utils/strategy_manager/multi_cluster_strategy_utils.cpp
+++ b/src/vpux_compiler/src/dialect/VPU/utils/strategy_manager/multi_cluster_strategy_utils.cpp
@@ -1219,7 +1219,8 @@ SmallVector<uint32_t> vpux::VPU::getDPUCostForNCEOp(VPU::NCEOpInterface nceOp, V
             }
             return vpunnLayers;
         };
-        vpunnLayers = tilingVPUNNLayer(vpunnLayers[0], outTiles);
+        auto layers = tilingVPUNNLayer(vpunnLayers[0], outTiles);
+        vpunnLayers = layers; 
     }
 
     // E#113592 For not supported SEP layer costs - optimize activation spills

--- a/src/vpux_compiler/src/dialect/const/utils/constant_folding_cache.cpp
+++ b/src/vpux_compiler/src/dialect/const/utils/constant_folding_cache.cpp
@@ -23,7 +23,10 @@ void Const::ConstantFoldingCache::enqueueRequest(const Const::FoldingRequest& fo
 
 Const::FoldingRequest Const::ConstantFoldingCache::getRequest() {
     Const::FoldingRequest result;
-    _requestQueue.pop(result);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+     _requestQueue.pop(result);
+#pragma GCC diagnostic pop
     return result;
 }
 

--- a/src/vpux_ngraph_transformations/src/passes/align_scales.cpp
+++ b/src/vpux_ngraph_transformations/src/passes/align_scales.cpp
@@ -400,7 +400,7 @@ bool AlignScales::run_on_model(const std::shared_ptr<ov::Model>& m) {
             continue;
         }
 
-        update_concat_out_fq(std::move(node), fqs_to_align);
+        update_concat_out_fq(node, fqs_to_align);
 
         if (fqs_to_align.size() > 2) {
             adjust_fqs_to_align(fqs_to_align);


### PR DESCRIPTION
## Summary
[Ubuntu24.04] llvm-project in vpux_plugin fails to compile due to:
```
/build/third_party/vpux_plugin/src/vpux_plugin/src/vpux_compiler/src/dialect/const/utils/constant_folding_cache.cpp:26:22:
/usr/include/c++/13/bits/atomic_base.h:481:25: error: 'void __atomic_store_8(volatile void*, long unsigned int, int)' writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
  481 |         __atomic_store_n(&_M_i, __i, int(__m));
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In member function 'vpux::Const::FoldingRequest vpux::Const::ConstantFoldingCache::getRequest()':
cc1plus: note: destination object is likely at address zero
```

```
error: redundant move in initialization [-Werror=redundant-move]
      update_concat_out_fq(std::move(node), fqs_to_align);
```

```
vpux_plugin/thirdparty/llvm-project/llvm/include/llvm/ADT/FunctionExtras.h:307:7: error: '<unnamed>.llvm::unique_function<__attribute__((const)) bool(mlir::OpOperand&)>::<unnamed>.llvm::detail::UniqueFunctionBase<bool, mlir::OpOperand&>::StorageUnion.llvm::detail::UniqueFunctionBase<bool, mlir::OpOperand&>::StorageUnionT::OutOfLineStorage' may be used uninitialized [-Werror=maybe-uninitialized]
      StorageUnion.OutOfLineStorage = RHS.StorageUnion.OutOfLineStorage;
```

```
c++/13/bits/stl_algobase.h:437:30: error: 'void* __builtin_memmove(void*, const void*, long unsigned int)' forming offset 200 is out of the bounds [0, 200] of object '<anonymous>' with type 'llvm::SmallVector<VPUNN::DPULayer>' [-Werror=array-bounds=]
       __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
```

etc

## Target Platform For Release Notes (Mandatory)

Aids the generation of release notes

- [x] VPUX30XX
- [x] VPUX31XX
- [x] VPUX37XX
- [ ] NONE (Not included in release notes)

## Classification of this Pull Request

- [ ] Maintenance
- [x] BUG
- [ ] Feature

## Related PRs

* [PR-xxx](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/xxx) description

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
