### PR TITLE
[Coverity] - Fix Attempting to access the managed object of an empty smart pointer record

### DIFF
--- a/src/vpux_utils/src/profiling/parser/parser.cpp
+++ b/src/vpux_utils/src/profiling/parser/parser.cpp
@@ -279,8 +279,11 @@ RawProfilingRecords parseDPUTaskProfiling(
                     record = std::make_shared<RawProfilingDPUHW27Record>(dpuTimings, taskMeta, variantId, currentPos,
                                                                          inClusterIndex);
                 }
-                record->checkData(!ignoreSanitizationErrors, log);
-                rawRecords.push_back(record);
+                // Check if record is initialized before using it
+                if (record != nullptr) {
+                    record->checkData(!ignoreSanitizationErrors, log);
+                    rawRecords.push_back(record);
+                }
             }
             // continue increment of currentPos to walk over non-used data
             ++currentPos;


### PR DESCRIPTION
## Summary
Copy of https://github.com/openvinotoolkit/npu_compiler/pull/50
Fix Attempting to access the managed object of an empty smart pointer record

## Target Platform For Release Notes
> Aids the generation of release notes

- [ ] NPU37XX
- [ ] NPU40XX
- [x] NONE (Not included in release notes)

## Classification of this Pull Request

- [ ] Maintenance
- [x] BUG
- [ ] Feature

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
