### PR TITLE
Bump urllib3 from 2.4.0 to 2.5.0 in /.github/actions/download-models

### DIFF
--- a/.github/actions/download-models/requirements.txt
+++ b/.github/actions/download-models/requirements.txt
@@ -102,10 +102,6 @@ charset-normalizer==3.4.1 \
     --hash=sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00 \
     --hash=sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616
     # via requests
-colorama==0.4.6 \
-    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
-    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via tqdm
 filelock==3.18.0 \
     --hash=sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2 \
     --hash=sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de
@@ -123,11 +119,13 @@ hf-xet==1.1.5 \
     --hash=sha256:dbba1660e5d810bd0ea77c511a99e9242d920790d0e63c0e4673ed36c4022d18 \
     --hash=sha256:f52c2fa3635b8c37c7764d8796dfa72706cc4eded19d638331161e82b0792e23 \
     --hash=sha256:fc874b5c843e642f45fd85cda1ce599e123308ad2901ead23d3510a47ff506d1
-    # via -r .github/actions/download-models/requirements.in
+    # via
+    #   -r requirements.in
+    #   huggingface-hub
 huggingface-hub==0.33.2 \
     --hash=sha256:3749498bfa91e8cde2ddc2c1db92c79981f40e66434c20133b39e5928ac9bcc5 \
     --hash=sha256:84221defaec8fa09c090390cd68c78b88e3c4c2b7befba68d3dc5aacbc3c2c5f
-    # via -r .github/actions/download-models/requirements.in
+    # via -r requirements.in
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -195,7 +193,7 @@ requests==2.32.4 \
     --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
     --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
-    #   -r .github/actions/download-models/requirements.in
+    #   -r requirements.in
     #   huggingface-hub
 tqdm==4.67.1 \
     --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
@@ -205,7 +203,7 @@ typing-extensions==4.13.2 \
     --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
     --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
     # via huggingface-hub
-urllib3==2.4.0 \
-    --hash=sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466 \
-    --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
+urllib3==2.5.0 \
+    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
+    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
     # via requests


### PR DESCRIPTION
## Summary
Bumps the pip group with 1 update in the /.github/actions/download-models directory: [urllib3](https://github.com/urllib3/urllib3).

Updates `urllib3` from 2.4.0 to 2.5.0

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/urllib3/urllib3/releases">urllib3's releases</a>.</em></p>
<blockquote>
<h2>2.5.0</h2>
<h2>🚀 urllib3 is fundraising for HTTP/2 support</h2>
<p><a href="https://sethmlarson.dev/urllib3-is-fundraising-for-http2-support">urllib3 is raising ~$40,000 USD</a> to release HTTP/2 support and ensure long-term sustainable maintenance of the project after a sharp decline in financial support. If your company or organization uses Python and would benefit from HTTP/2 support in Requests, pip, cloud SDKs, and thousands of other projects <a href="https://opencollective.com/urllib3">please consider contributing financially</a> to ensure HTTP/2 support is developed sustainably and maintained for the long-haul.</p>
<p>Thank you for your support.</p>
<h1>Security issues</h1>
<p>urllib3 2.5.0 fixes two moderate security issues:</p>
<ul>
<li>Pool managers now properly control redirects when <code>retries</code> is passed — CVE-2025-50181 reported by <a href="https://github.com/sandumjacob"><code>@​sandumjacob</code></a> (5.3 Medium, GHSA-pq67-6m6q-mj2v)</li>
<li>Redirects are now controlled by urllib3 in the Node.js runtime — CVE-2025-50182 (5.3 Medium, GHSA-48p4-8xcf-vxj5)</li>
</ul>
<h1>Features</h1>
<ul>
<li>Added support for the <code>compression.zstd</code> module that is new in Python 3.14. See <a href="https://peps.python.org/pep-0784/">PEP 784</a> for more information. (<a href="https://redirect.github.com/urllib3/urllib3/issues/3610">#3610</a>)</li>
<li>Added support for version 0.5 of <code>hatch-vcs</code> (<a href="https://redirect.github.com/urllib3/urllib3/issues/3612">#3612</a>)</li>
</ul>
<h1>Bugfixes</h1>
<ul>
<li>Raised exception for <code>HTTPResponse.shutdown</code> on a connection already released to the pool. (<a href="https://redirect.github.com/urllib3/urllib3/issues/3581">#3581</a>)</li>
<li>Fixed incorrect <code>CONNECT</code> statement when using an IPv6 proxy with <code>connection_from_host</code>. Previously would not be wrapped in <code>[]</code>. (<a href="https://redirect.github.com/urllib3/urllib3/issues/3615">#3615</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/urllib3/urllib3/blob/main/CHANGES.rst">urllib3's changelog</a>.</em></p>
<blockquote>
<h1>2.5.0 (2025-06-18)</h1>
<h2>Features</h2>
<ul>
<li>Added support for the <code>compression.zstd</code> module that is new in Python 3.14.
See <code>PEP 784 &lt;https://peps.python.org/pep-0784/&gt;</code>_ for more information. (<code>[#3610](https://github.com/urllib3/urllib3/issues/3610) &lt;https://github.com/urllib3/urllib3/issues/3610&gt;</code>__)</li>
<li>Added support for version 0.5 of <code>hatch-vcs</code> (<code>[#3612](https://github.com/urllib3/urllib3/issues/3612) &lt;https://github.com/urllib3/urllib3/issues/3612&gt;</code>__)</li>
</ul>
<h2>Bugfixes</h2>
<ul>
<li>Fixed a security issue where restricting the maximum number of followed
redirects at the <code>urllib3.PoolManager</code> level via the <code>retries</code> parameter
did not work.</li>
<li>Made the Node.js runtime respect redirect parameters such as <code>retries</code>
and <code>redirects</code>.</li>
<li>Raised exception for <code>HTTPResponse.shutdown</code> on a connection already released to the pool. (<code>[#3581](https://github.com/urllib3/urllib3/issues/3581) &lt;https://github.com/urllib3/urllib3/issues/3581&gt;</code>__)</li>
<li>Fixed incorrect <code>CONNECT</code> statement when using an IPv6 proxy with <code>connection_from_host</code>. Previously would not be wrapped in <code>[]</code>. (<code>[#3615](https://github.com/urllib3/urllib3/issues/3615) &lt;https://github.com/urllib3/urllib3/issues/3615&gt;</code>__)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/urllib3/urllib3/commit/aaab4eccc10c965897540b21e15f11859d0b62e7"><code>aaab4ec</code></a> Release 2.5.0</li>
<li><a href="https://github.com/urllib3/urllib3/commit/7eb4a2aafe49a279c29b6d1f0ed0f42e9736194f"><code>7eb4a2a</code></a> Merge commit from fork</li>
<li><a href="https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857"><code>f05b132</code></a> Merge commit from fork</li>
<li><a href="https://github.com/urllib3/urllib3/commit/d03fe327a71d09728512217149f269763671f296"><code>d03fe32</code></a> Fix HTTP tunneling with IPv6 in older Python versions</li>
<li><a href="https://github.com/urllib3/urllib3/commit/11661e9bb4278e43d081f47a516e287a928c2206"><code>11661e9</code></a> Bump github/codeql-action from 3.28.0 to 3.29.0 (<a href="https://redirect.github.com/urllib3/urllib3/issues/3624">#3624</a>)</li>
<li><a href="https://github.com/urllib3/urllib3/commit/6a0ecc6b16fe30f721021b44a81d19615098c71e"><code>6a0ecc6</code></a> Update v2 migration guide to 2.4.0 (<a href="https://redirect.github.com/urllib3/urllib3/issues/3621">#3621</a>)</li>
<li><a href="https://github.com/urllib3/urllib3/commit/8e32e60d9024c05bc6f7adda08bdf6c539d0b0d4"><code>8e32e60</code></a> Raise exception for shutdown on a connection already released to the pool (<a href="https://redirect.github.com/urllib3/urllib3/issues/3">#3</a>...</li>
<li><a href="https://github.com/urllib3/urllib3/commit/9996e0fbf90b77083ad3c73737a6c6395703faa9"><code>9996e0f</code></a> Fix emscripten CI for Chrome 137+ (<a href="https://redirect.github.com/urllib3/urllib3/issues/3599">#3599</a>)</li>
<li><a href="https://github.com/urllib3/urllib3/commit/4fd1a99a59725faf0efc946ce3b6bc9a194420af"><code>4fd1a99</code></a> Bump RECENT_DATE (<a href="https://redirect.github.com/urllib3/urllib3/issues/3617">#3617</a>)</li>
<li><a href="https://github.com/urllib3/urllib3/commit/c4b5917e911a90c8bf279448df8952a682294135"><code>c4b5917</code></a> Add support for the new <code>compression.zstd</code> module in Python 3.14 (<a href="https://redirect.github.com/urllib3/urllib3/issues/3611">#3611</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/urllib3/urllib3/compare/2.4.0...2.5.0">compare view</a></li>
</ul>
</details>
<br />

## Target Platform For Release Notes
> Aids the generation of release notes

- [ ] NPU37XX
- [ ] NPU40XX
- [x] NONE (Not included in release notes)

## Classification of this Pull Request

- [x] Maintenance
- [ ] BUG
- [ ] Feature

## Code Review Survey (Copy and Complete in your code review)

- number_minutes_spent_on_review[0]
- number_p1_defects_found[0]
- number_p2_defects_found[0]
- number_p3_defects_found[0]
- number_p4_defects_found[0]
