### PR TITLE
[IE] Guard ConvertFCToConv against zero-sized channel dimensions

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,75 @@
+# [IE] Guard ConvertFCToConv against zero-sized channel dimensions
+
+## Summary
+
+`ConvertFCToConvPass::safeRunOnFunc()` unconditionally marks `IE::FullyConnectedOp` as illegal via `target.addIllegalOp`, forcing every FC op through conversion to `IE::ConvolutionOp`. The `FullyConnectedOpConverter::matchAndRewrite()` blindly reshapes 2-D FC operands to 4-D `{N, C, 1, 1}` without validating that the channel dimension is positive. When per-group INT4 quantization decomposition (e.g. `group_size=128`) produces `IE::FullyConnectedOp` nodes whose channel dimension is zero, the reshape yields `tensor<Nx0x1x1>`, which causes `IE::ConvolutionOp` type inference to abort with:
+
+```
+LLVM ERROR: Failed to infer result type(s).
+```
+
+at location `as_convolution`. The SIGABRT kills the process immediately and cannot be caught by the caller.
+
+This PR replaces `addIllegalOp<IE::FullyConnectedOp>()` with `addDynamicallyLegalOp<IE::FullyConnectedOp>()` using a predicate that exempts zero-dim and non-rank-2 FC ops from the illegality constraint. Exempt FC ops are considered "legal" and survive the pass unchanged. Valid FC ops remain "illegal" and are converted to convolutions as before.
+
+A defense-in-depth guard in `matchAndRewrite()` is also retained as a belt-and-suspenders safety net.
+
+## Reproduction
+
+Observed when compiling Qwen3-0.6B (28 layers, INT4 grouped quantization, `openvino-int4-npu` format) for the NPU as a speculative decoding draft model in OpenVINO GenAI heterogeneous mode (`GPU target + NPU draft`):
+
+```python
+import openvino_genai as ov_genai
+
+pipeline = ov_genai.LLMPipeline(
+    "models/qwen3-14b/openvino-int4-gpu/",
+    "GPU",
+    draft_model=ov_genai.draft_model("models/qwen3-0.6b/openvino-int4-npu/", "NPU"),
+    scheduler_config=scheduler,
+)
+```
+
+The VPUX compiler aborts during model compilation (before inference) at the `self_attn.v_proj` linear layer in transformer block 0:
+
+```
+[ERROR] [vpux-compiler] Got Diagnostic at
+  loc(fused<{name = "__module.model.layers.0.self_attn.v_proj/ov_ext::linear/MatMul",
+  type = "MatMul"}>["...", "fc_decomposed", "matmul_0", "as_convolution"]) :
+  Channels count of input tensor shape and filter shape must be the same: 0 != 8
+
+LLVM ERROR: Failed to infer result type(s):
+"IE.Convolution"(...) {} : (tensor<1x0x1x1xf16>, tensor<1x8x1x1xf16>) -> ( ??? )
+```
+
+**Environment:** Intel Core Ultra 7 258V (Lunar Lake), NPU driver 32.0.100.4514, OpenVINO 2026.0, Windows 11 Pro.
+
+## Root Cause
+
+The location trail `["fc_decomposed", "matmul_0", "as_convolution"]` reveals a multi-pass interaction:
+
+1. **`GroupWisePatternRewriter`** (decompose multi-ZP quantization) decomposes per-group INT4 FCs into main/correction branches, producing `IE::FullyConnectedOp` with `fc_decomposed` tag.
+2. **`UnrollFullyConnected`** unrolls the decomposed FC, producing sub-FCs with `matmul_0` tag — one of which has a zero-dim input.
+3. **`ConvertFCToConv`** attempts to convert the zero-dim FC to `IE::ConvolutionOp`, hitting the SIGABRT.
+
+The zero-dim FC is a valid intermediate IR artifact from the multi-pass interaction. `ConvertFCToConv` must tolerate it.
+
+## Changes
+
+**`src/vpux_compiler/src/dialect/IE/transforms/passes/convert_fc_to_conv.cpp`**:
+- **`safeRunOnFunc()`**: Replaced `target.addIllegalOp<IE::FullyConnectedOp>()` with `target.addDynamicallyLegalOp<IE::FullyConnectedOp>(predicate)`. The predicate returns `true` (legal/exempt) for FC ops with non-rank-2 shapes or any dimension ≤ 0, and `false` (illegal/must-convert) for valid 2-D FC ops. This follows the existing pattern in `AdjustNCEOpsWithI32InputsPass::safeRunOnFunc()`.
+- **`matchAndRewrite()`**: Retained the dimension guard as defense-in-depth (unreachable under normal conditions due to the predicate, but protects against future changes).
+
+**`tests/lit/NPU/dialect/IE/passes/convert_fc_to_conv_zero_dim_guard.mlir`**:
+- Changed from negative test (`not vpux-opt`, checking `failed to legalize`) to positive test: the zero-dim `IE.FullyConnected` now **survives** the pass unchanged.
+- `CHECK-LABEL: @PreserveZeroDimFC` / `CHECK: IE.FullyConnected` confirms the op is preserved.
+
+## Testing
+
+- LIT test `@PreserveZeroDimFC`: `vpux-opt` exits with code 0, `FileCheck` confirms `IE.FullyConnected` survives in the output IR.
+- Existing `convert_fc_to_conv.mlir` positive test is unaffected — valid FC ops are still converted to convolutions.
+- No behavioral change for any model that only contains valid-shaped FC ops.
+
+## Related
+
+- OpenVINO issue: https://github.com/openvinotoolkit/openvino/issues/34450
+- OpenVINO GenAI duplicate: https://github.com/openvinotoolkit/openvino.genai/issues/3429

--- a/src/vpux_compiler/src/dialect/IE/transforms/passes/convert_fc_to_conv.cpp
+++ b/src/vpux_compiler/src/dialect/IE/transforms/passes/convert_fc_to_conv.cpp
@@ -62,12 +62,30 @@ private:
 mlir::LogicalResult ConvertFCToConvPass::FullyConnectedOpConverter::matchAndRewrite(
         IE::FullyConnectedOp origOp, mlir::PatternRewriter& rewriter) const {
     const auto inputShape = mlir::cast<vpux::NDTypeInterface>(origOp.getInput().getType()).getShape().raw();
+    const auto weightsShape = mlir::cast<vpux::NDTypeInterface>(origOp.getWeights().getType()).getShape().raw();
+
+    // Defense-in-depth: reject FC ops with degenerate shapes.
+    // The addDynamicallyLegalOp predicate in safeRunOnFunc() already exempts
+    // these from conversion; this guard is belt-and-suspenders for robustness.
+    if (inputShape.size() != 2 || weightsShape.size() != 2) {
+        return mlir::failure();
+    }
+    for (auto dim : inputShape) {
+        if (dim <= 0) {
+            return mlir::failure();
+        }
+    }
+    for (auto dim : weightsShape) {
+        if (dim <= 0) {
+            return mlir::failure();
+        }
+    }
+
     const std::array<int64_t, 4> newInShape = {inputShape[0], inputShape[1], 1, 1};
     const auto inputShapeAttr = getIntArrayAttr(getContext(), newInShape);
     auto newInput =
             rewriter.create<IE::ReshapeOp>(takeOpLoc(origOp, "input_reshape"), origOp.getInput(), inputShapeAttr);
 
-    const auto weightsShape = mlir::cast<vpux::NDTypeInterface>(origOp.getWeights().getType()).getShape().raw();
     const std::array<int64_t, 4> newWeightsShape = {weightsShape[0], weightsShape[1], 1, 1};
     const auto filterShapeAttr = getIntArrayAttr(getContext(), newWeightsShape);
     auto newFilter =
@@ -105,7 +123,26 @@ void ConvertFCToConvPass::safeRunOnFunc() {
     auto& ctx = getContext();
 
     mlir::ConversionTarget target(ctx);
-    target.addIllegalOp<IE::FullyConnectedOp>();
+    // Mark zero-dim / non-rank-2 FC ops as dynamically legal so they survive
+    // the pass untouched.  Per-group INT4 quantization decomposition can
+    // produce FC ops with zero-sized channel dimensions that cannot be reshaped
+    // to 4-D convolution format (see openvinotoolkit/openvino#34450).
+    target.addDynamicallyLegalOp<IE::FullyConnectedOp>([](IE::FullyConnectedOp op) {
+        const auto inShape = mlir::cast<vpux::NDTypeInterface>(op.getInput().getType()).getShape().raw();
+        const auto wShape = mlir::cast<vpux::NDTypeInterface>(op.getWeights().getType()).getShape().raw();
+        if (inShape.size() != 2 || wShape.size() != 2) {
+            return true;
+        }
+        for (auto d : inShape) {
+            if (d <= 0)
+                return true;
+        }
+        for (auto d : wShape) {
+            if (d <= 0)
+                return true;
+        }
+        return false;
+    });
     target.addLegalOp<IE::ConvolutionOp>();
     target.addLegalOp<IE::ReshapeOp>();
 

--- a/tests/lit/NPU/dialect/IE/passes/convert_fc_to_conv_zero_dim_guard.mlir
+++ b/tests/lit/NPU/dialect/IE/passes/convert_fc_to_conv_zero_dim_guard.mlir
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2022-2026 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Regression test: ConvertFCToConv must not crash (SIGABRT) when an
+// IE.FullyConnected has a zero-sized channel dimension.  This can occur
+// when per-group INT4 quantization decomposition produces intermediate
+// FC operations with degenerate shapes.
+//
+// Before the fix, vpux-opt would hit:
+//   LLVM ERROR: Failed to infer result type(s).
+// because IE.Convolution type-inference receives a tensor<Nx0x1x1> input.
+//
+// After the fix, the zero-dim FC op is dynamically marked as legal and
+// survives the pass unchanged — no crash, no "failed to legalize".
+
+// RUN: vpux-opt --split-input-file --init-compiler="vpu-arch=%arch%" --convert-fc-to-conv %s | FileCheck %s
+// REQUIRES: arch-NPU37XX || arch-NPU40XX || arch-NPU50XX
+
+// CHECK-LABEL: @PreserveZeroDimFC
+// CHECK: IE.FullyConnected
+func.func @PreserveZeroDimFC(%arg0: tensor<1x0xf16>) -> tensor<1x64xf16> {
+    %weights = const.Declare tensor<64x0xf16> = dense<0.0> : tensor<64x0xf16>
+    %0 = IE.FullyConnected(%arg0, %weights) : tensor<1x0xf16>, tensor<64x0xf16> -> tensor<1x64xf16>
+    return %0 : tensor<1x64xf16>
+}


### PR DESCRIPTION
# [IE] Guard ConvertFCToConv against zero-sized channel dimensions

## Summary

`ConvertFCToConvPass::safeRunOnFunc()` unconditionally marks `IE::FullyConnectedOp` as illegal via `target.addIllegalOp`, forcing every FC op through conversion to `IE::ConvolutionOp`. The `FullyConnectedOpConverter::matchAndRewrite()` blindly reshapes 2-D FC operands to 4-D `{N, C, 1, 1}` without validating that the channel dimension is positive. When per-group INT4 quantization decomposition (e.g. `group_size=128`) produces `IE::FullyConnectedOp` nodes whose channel dimension is zero, the reshape yields `tensor<Nx0x1x1>`, which causes `IE::ConvolutionOp` type inference to abort with:

```
LLVM ERROR: Failed to infer result type(s).
```

at location `as_convolution`. The SIGABRT kills the process immediately and cannot be caught by the caller.

This PR replaces `addIllegalOp<IE::FullyConnectedOp>()` with `addDynamicallyLegalOp<IE::FullyConnectedOp>()` using a predicate that exempts zero-dim and non-rank-2 FC ops from the illegality constraint. Exempt FC ops are considered "legal" and survive the pass unchanged. Valid FC ops remain "illegal" and are converted to convolutions as before.

A defense-in-depth guard in `matchAndRewrite()` is also retained as a belt-and-suspenders safety net.

## Reproduction

Observed when compiling Qwen3-0.6B (28 layers, INT4 grouped quantization, `openvino-int4-npu` format) for the NPU as a speculative decoding draft model in OpenVINO GenAI heterogeneous mode (`GPU target + NPU draft`):

```python
import openvino_genai as ov_genai

pipeline = ov_genai.LLMPipeline(
    "models/qwen3-14b/openvino-int4-gpu/",
    "GPU",
    draft_model=ov_genai.draft_model("models/qwen3-0.6b/openvino-int4-npu/", "NPU"),
    scheduler_config=scheduler,
)
```

The VPUX compiler aborts during model compilation (before inference) at the `self_attn.v_proj` linear layer in transformer block 0:

```
[ERROR] [vpux-compiler] Got Diagnostic at
  loc(fused<{name = "__module.model.layers.0.self_attn.v_proj/ov_ext::linear/MatMul",
  type = "MatMul"}>["...", "fc_decomposed", "matmul_0", "as_convolution"]) :
  Channels count of input tensor shape and filter shape must be the same: 0 != 8

LLVM ERROR: Failed to infer result type(s):
"IE.Convolution"(...) {} : (tensor<1x0x1x1xf16>, tensor<1x8x1x1xf16>) -> ( ??? )
```

**Environment:** Intel Core Ultra 7 258V (Lunar Lake), NPU driver 32.0.100.4514, OpenVINO 2026.0, Windows 11 Pro.

## Root Cause

The location trail `["fc_decomposed", "matmul_0", "as_convolution"]` reveals a multi-pass interaction:

1. **`GroupWisePatternRewriter`** (decompose multi-ZP quantization) decomposes per-group INT4 FCs into main/correction branches, producing `IE::FullyConnectedOp` with `fc_decomposed` tag.
2. **`UnrollFullyConnected`** unrolls the decomposed FC, producing sub-FCs with `matmul_0` tag — one of which has a zero-dim input.
3. **`ConvertFCToConv`** attempts to convert the zero-dim FC to `IE::ConvolutionOp`, hitting the SIGABRT.

The zero-dim FC is a valid intermediate IR artifact from the multi-pass interaction. `ConvertFCToConv` must tolerate it.

## Changes

**`src/vpux_compiler/src/dialect/IE/transforms/passes/convert_fc_to_conv.cpp`**:
- **`safeRunOnFunc()`**: Replaced `target.addIllegalOp<IE::FullyConnectedOp>()` with `target.addDynamicallyLegalOp<IE::FullyConnectedOp>(predicate)`. The predicate returns `true` (legal/exempt) for FC ops with non-rank-2 shapes or any dimension ≤ 0, and `false` (illegal/must-convert) for valid 2-D FC ops. This follows the existing pattern in `AdjustNCEOpsWithI32InputsPass::safeRunOnFunc()`.
- **`matchAndRewrite()`**: Retained the dimension guard as defense-in-depth (unreachable under normal conditions due to the predicate, but protects against future changes).

**`tests/lit/NPU/dialect/IE/passes/convert_fc_to_conv_zero_dim_guard.mlir`**:
- Changed from negative test (`not vpux-opt`, checking `failed to legalize`) to positive test: the zero-dim `IE.FullyConnected` now **survives** the pass unchanged.
- `CHECK-LABEL: @PreserveZeroDimFC` / `CHECK: IE.FullyConnected` confirms the op is preserved.

## Testing

- LIT test `@PreserveZeroDimFC`: `vpux-opt` exits with code 0, `FileCheck` confirms `IE.FullyConnected` survives in the output IR.
- Existing `convert_fc_to_conv.mlir` positive test is unaffected — valid FC ops are still converted to convolutions.
- No behavioral change for any model that only contains valid-shaped FC ops.

## AI Usage

-This PR was developed with AI assistance (GitHub Copilot) for source code analysis, fix implementation, and PR description drafting. All code was reviewed and validated by the contributor.

## Related

- OpenVINO issue: https://github.com/openvinotoolkit/openvino/issues/34450
- OpenVINO GenAI duplicate: https://github.com/openvinotoolkit/openvino.genai/issues/3429