### PR TITLE
[IE] Defense-in-depth: reject zero-dim FC ops in UnrollFullyConnected

### DIFF
--- a/PR2_DESCRIPTION.md
+++ b/PR2_DESCRIPTION.md
@@ -1,0 +1,36 @@
+# [IE] Defense-in-depth: reject zero-dim FC ops in UnrollFullyConnected
+
+## Summary
+
+`UnrollFullyConnected::matchAndRewrite()` does not guard against zero or negative dimensions in `IE::FullyConnectedOp` operands before entering the `splitLeftInput` / `reshapeTo2d` unrolling logic. When per-group INT4 quantization decomposition (e.g. `GroupWisePatternRewriter` with `group_size=128`) produces intermediate FC ops with degenerate shapes, the unrolling pass propagates zero-dim tensors into unrolled sub-FCs. These poisoned sub-FCs then reach downstream passes like `ConvertFCToConv`, triggering a process-killing SIGABRT in `IE::ConvolutionOp` type inference.
+
+This PR adds a defense-in-depth guard in `matchAndRewrite()` that rejects FC ops with zero or negative batch dimension or weight dimensions. The existing `inputChannels < numChunks` guard already catches some zero-dim edge cases on the LHS channel axis; this addition covers the batch dimension and all weight dimensions.
+
+## Context
+
+This is a companion to the `ConvertFCToConv` fix (#265). That fix prevents the crash at the `ConvertFCToConv` layer; this fix prevents degenerate shapes from propagating through `UnrollFullyConnected` in the first place.
+
+The `ConvertFCToConv` fix is the primary crash prevention mechanism. This `UnrollFullyConnected` guard is strictly defense-in-depth — it hardens an earlier pass in the pipeline to reject shapes that should never have reached it.
+
+## Root Cause
+
+The location trail from the original crash (`["fc_decomposed", "matmul_0", "as_convolution"]`) shows that `UnrollFullyConnected` runs between `GroupWisePatternRewriter` and `ConvertFCToConv`. When the decomposition produces a zero-dim FC, `UnrollFullyConnected` blindly enters `splitLeftInput`, which slices the LHS tensor into `numChunks` equal blocks. If the batch dimension is zero, the sliced sub-FCs inherit the zero-dim shape and propagate it downstream.
+
+## Changes
+
+**`src/vpux_compiler/src/dialect/IE/transforms/passes/unroll_fully_connected.cpp`**:
+- Added +18 lines after the existing `inputChannels < numChunks` guard (line ~475).
+- **Batch dimension check**: `lhsShape[Dim(0)] <= 0` → return `mlir::failure()` with debug log.
+- **Weight dimensions check**: Iterates all weight dimensions via `irange(wShape.size())`; any dimension `<= 0` → return `mlir::failure()` with debug log.
+- Block-scoped `wShape` variable to avoid shadowing outer variables.
+- References `openvinotoolkit/openvino#34450` in comment.
+
+## Testing
+
+- No dedicated LIT test: reaching the guard code path requires constructing a full `Concat→Reshape→Transpose` pattern with zero-dim tensors, which is fragile and tightly coupled to internal IR structure. The guard is defense-in-depth; the primary crash prevention is validated by the `ConvertFCToConv` LIT test.
+- Existing `unroll_fully_connected.mlir` regression test passes on all three architectures (NPU37XX, NPU40XX, NPU50XX) — no behavioral change for valid-shaped FC ops.
+
+## Related
+
+- OpenVINO issue: https://github.com/openvinotoolkit/openvino/issues/34450
+- Companion PR: #265

--- a/PR2_DESCRIPTION.md
+++ b/PR2_DESCRIPTION.md
@@ -27,7 +27,7 @@ The location trail from the original crash (`["fc_decomposed", "matmul_0", "as_c
 
 ## Testing
 
-- No dedicated LIT test: reaching the guard code path requires constructing a full `Concat→Reshape→Transpose` pattern with zero-dim tensors, which is fragile and tightly coupled to internal IR structure. The guard is defense-in-depth; the primary crash prevention is validated by the `ConvertFCToConv` LIT test.
+- **LIT test added**: `tests/lit/NPU/dialect/IE/passes/unroll_fully_connected_zero_dim_guard.mlir` — constructs a `FakeQuantize→Concat→AffineReshape→Transpose→FullyConnected` pattern with a zero batch dimension (`tensor<0x3072xf32>`). Verifies the guard catches `lhsShape[Dim(0)] <= 0` and preserves the FC unchanged.
 - Existing `unroll_fully_connected.mlir` regression test passes on all three architectures (NPU37XX, NPU40XX, NPU50XX) — no behavioral change for valid-shaped FC ops.
 
 ## Related

--- a/src/vpux_compiler/src/dialect/IE/transforms/passes/unroll_fully_connected.cpp
+++ b/src/vpux_compiler/src/dialect/IE/transforms/passes/unroll_fully_connected.cpp
@@ -475,6 +475,24 @@ mlir::LogicalResult UnrollFullyConnected::matchAndRewrite(IE::FullyConnectedOp o
         return mlir::failure();
     }
 
+    // Defense-in-depth: reject FC ops with zero or negative dimensions in
+    // either operand.  Prevents degenerate shapes produced by multi-pass
+    // quantization decomposition from propagating into unrolled sub-FCs.
+    // See openvinotoolkit/openvino#34450.
+    if (lhsShape[Dim(0)] <= 0) {
+        nestedLog.debug("Zero or negative batch dimension at loc: {0}", opLoc);
+        return mlir::failure();
+    }
+    {
+        const auto wShape = getShape(origOp.getWeights());
+        for (auto idx : irange(wShape.size())) {
+            if (wShape[Dim(idx)] <= 0) {
+                nestedLog.debug("Zero or negative weight dimension at loc: {0}", opLoc);
+                return mlir::failure();
+            }
+        }
+    }
+
     const auto rhsChunks = reshapeTo2d(matMulInputs, rewriter);
     // Split left input into the number of chunks:
     const auto lhsChunks = splitLeftInput(origOp.getInput(), numChunks, opLoc, rewriter);

--- a/tests/lit/NPU/dialect/IE/passes/unroll_fully_connected_zero_dim_guard.mlir
+++ b/tests/lit/NPU/dialect/IE/passes/unroll_fully_connected_zero_dim_guard.mlir
@@ -1,0 +1,59 @@
+//
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// RUN: vpux-opt --split-input-file --init-compiler="vpu-arch=%arch%" --unroll-fully-connected %s | FileCheck %s
+// REQUIRES: arch-NPU37XX || arch-NPU40XX || arch-NPU50XX
+
+#CN = affine_map<(d0, d1) -> (d1, d0)>
+
+// CHECK-LABEL: @DontUnrollZeroBatchDim
+// CHECK-SAME:   [[LHS:%arg[0-9]+]]: tensor<0x3072xf32>,
+// CHECK-SAME:   [[WEIGHTS:%arg[0-9]+]]: tensor<1x1024x4096xf32>,
+// CHECK-SAME:   [[IN_PARAM:%arg[0-9]+]]: tensor<1x1x1xf32>,
+// CHECK-SAME:   [[OUT_PARAM:%arg[0-9]+]]: tensor<1x1x4096xf32>
+func.func @DontUnrollZeroBatchDim(%LHS: tensor<0x3072xf32>,
+                        %WEIGHTS: tensor<1x1024x4096xf32>,
+                        %IN_PARAM: tensor<1x1x1xf32>,
+                        %OUT_PARAM: tensor<1x1x4096xf32>) -> tensor<0x4096xf32> {
+    %RHS_1 = IE.FakeQuantize(%WEIGHTS, %IN_PARAM, %IN_PARAM, %OUT_PARAM, %OUT_PARAM) {
+        auto_broadcast = #IE.auto_broadcast_type<NUMPY>, levels = 16 : i64
+    } : tensor<1x1024x4096xf32>, tensor<1x1x1xf32>, tensor<1x1x1xf32>, tensor<1x1x4096xf32>, tensor<1x1x4096xf32> -> tensor<1x1024x4096xf32>
+    %RHS_2 = IE.FakeQuantize(%WEIGHTS, %IN_PARAM, %IN_PARAM, %OUT_PARAM, %OUT_PARAM) {
+        auto_broadcast = #IE.auto_broadcast_type<NUMPY>, levels = 16 : i64
+    } : tensor<1x1024x4096xf32>, tensor<1x1x1xf32>, tensor<1x1x1xf32>, tensor<1x1x4096xf32>, tensor<1x1x4096xf32> -> tensor<1x1024x4096xf32>
+    %RHS_3 = IE.FakeQuantize(%WEIGHTS, %IN_PARAM, %IN_PARAM, %OUT_PARAM, %OUT_PARAM) {
+        auto_broadcast = #IE.auto_broadcast_type<NUMPY>, levels = 16 : i64
+    } : tensor<1x1024x4096xf32>, tensor<1x1x1xf32>, tensor<1x1x1xf32>, tensor<1x1x4096xf32>, tensor<1x1x4096xf32> -> tensor<1x1024x4096xf32>
+
+    %CONCAT_RHS = IE.Concat(%RHS_1, %RHS_2, %RHS_3) {
+        per_axis = #IE.Concat<axis = 0 : i64>
+    } : tensor<1x1024x4096xf32>, tensor<1x1024x4096xf32>, tensor<1x1024x4096xf32> -> tensor<3x1024x4096xf32>
+
+    %RESHAPE_RHS = IE.AffineReshape(%CONCAT_RHS) {
+        dim_mapping = [[0], [0], [1]],
+        shape_value = [3072, 4096]
+    } : tensor<3x1024x4096xf32> -> tensor<3072x4096xf32>
+
+    %TRANSPOSE_RHS = IE.Transpose(%RESHAPE_RHS) {
+        order_value = #CN
+    } : tensor<3072x4096xf32> -> tensor<4096x3072xf32>
+
+    %GEMM = IE.FullyConnected(%LHS, %TRANSPOSE_RHS) : tensor<0x3072xf32>, tensor<4096x3072xf32> -> tensor<0x4096xf32>
+
+    return %GEMM : tensor<0x4096xf32>
+
+    // The zero batch dimension passes the existing inputChannels divisibility check
+    // (3072 >= 3, 3072 % 3 == 0) but the defense-in-depth guard catches lhsShape[Dim(0)] <= 0
+    // and returns failure, preserving the FC unchanged.
+    // CHECK:   [[RHS_1:%.+]] = IE.FakeQuantize
+    // CHECK:   [[RHS_2:%.+]] = IE.FakeQuantize
+    // CHECK:   [[RHS_3:%.+]] = IE.FakeQuantize
+    // CHECK:   [[CONCAT:%.+]] = IE.Concat([[RHS_1]], [[RHS_2]], [[RHS_3]])
+    // CHECK:   [[RESHAPE:%.+]] = IE.AffineReshape([[CONCAT]])
+    // CHECK:   [[TRANSPOSE:%.+]] = IE.Transpose([[RESHAPE]])
+    // CHECK:   [[GEMM:%.+]] = IE.FullyConnected([[LHS]], [[TRANSPOSE]])
+
+    // CHECK:   return [[GEMM]]
+}


### PR DESCRIPTION
# [IE] Defense-in-depth: reject zero-dim FC ops in UnrollFullyConnected

## Summary

`UnrollFullyConnected::matchAndRewrite()` does not guard against zero or negative dimensions in `IE::FullyConnectedOp` operands before entering the `splitLeftInput` / `reshapeTo2d` unrolling logic. When per-group INT4 quantization decomposition (e.g. `GroupWisePatternRewriter` with `group_size=128`) produces intermediate FC ops with degenerate shapes, the unrolling pass propagates zero-dim tensors into unrolled sub-FCs. These poisoned sub-FCs then reach downstream passes like `ConvertFCToConv`, triggering a process-killing SIGABRT in `IE::ConvolutionOp` type inference.

This PR adds a defense-in-depth guard in `matchAndRewrite()` that rejects FC ops with zero or negative batch dimension or weight dimensions. The existing `inputChannels < numChunks` guard already catches some zero-dim edge cases on the LHS channel axis; this addition covers the batch dimension and all weight dimensions.

## Context

This is a companion to the `ConvertFCToConv` fix (#265). That fix prevents the crash at the `ConvertFCToConv` layer; this fix prevents degenerate shapes from propagating through `UnrollFullyConnected` in the first place.

The `ConvertFCToConv` fix is the primary crash prevention mechanism. This `UnrollFullyConnected` guard is strictly defense-in-depth — it hardens an earlier pass in the pipeline to reject shapes that should never have reached it.

## Root Cause

The location trail from the original crash (`["fc_decomposed", "matmul_0", "as_convolution"]`) shows that `UnrollFullyConnected` runs between `GroupWisePatternRewriter` and `ConvertFCToConv`. When the decomposition produces a zero-dim FC, `UnrollFullyConnected` blindly enters `splitLeftInput`, which slices the LHS tensor into `numChunks` equal blocks. If the batch dimension is zero, the sliced sub-FCs inherit the zero-dim shape and propagate it downstream.

## Changes

**`src/vpux_compiler/src/dialect/IE/transforms/passes/unroll_fully_connected.cpp`**:
- Added +18 lines after the existing `inputChannels < numChunks` guard (line ~475).
- **Batch dimension check**: `lhsShape[Dim(0)] <= 0` → return `mlir::failure()` with debug log.
- **Weight dimensions check**: Iterates all weight dimensions via `irange(wShape.size())`; any dimension `<= 0` → return `mlir::failure()` with debug log.
- Block-scoped `wShape` variable to avoid shadowing outer variables.
- References `openvinotoolkit/openvino#34450` in comment.

## Testing

- **LIT test added**: `tests/lit/NPU/dialect/IE/passes/unroll_fully_connected_zero_dim_guard.mlir` — constructs a `FakeQuantize→Concat→AffineReshape→Transpose→FullyConnected` pattern with a zero batch dimension (`tensor<0x3072xf32>`). Verifies the guard catches `lhsShape[Dim(0)] <= 0` and preserves the FC unchanged.
- Existing `unroll_fully_connected.mlir` regression test passes on all three architectures (NPU37XX, NPU40XX, NPU50XX) — no behavioral change for valid-shaped FC ops.

## AI Usage

-This PR was developed with AI assistance (GitHub Copilot) for source code analysis, fix implementation, and PR description drafting. All code was reviewed and validated by the contributor.

## Related

- OpenVINO issue: https://github.com/openvinotoolkit/openvino/issues/34450
- Companion PR: #265
