### PR TITLE
[IE] UnrollGroupQuantize: make unrolled slice locations unique per consumer

### DIFF
--- a/src/vpux_compiler/src/dialect/IE/transforms/passes/unroll_group_quantize.cpp
+++ b/src/vpux_compiler/src/dialect/IE/transforms/passes/unroll_group_quantize.cpp
@@ -28,8 +28,8 @@ public:
 public:
     mlir::LogicalResult matchAndRewrite(ConcreteOp origOp, mlir::PatternRewriter& rewriter) const final;
     mlir::Value getValue(const mlir::ValueRange values, const int64_t idx) const;
-    SmallVector<mlir::Value> splitValue(const mlir::Value val, const int64_t axis,
-                                        mlir::PatternRewriter& rewriter) const;
+    SmallVector<mlir::Value> splitValue(const mlir::Value val, const int64_t axis, mlir::PatternRewriter& rewriter,
+                                        mlir::Operation* consumerOp, StringRef operandTag) const;
 
 private:
     virtual SmallVector<mlir::Value> splitInputs(ConcreteOp origOp, const int64_t axis,
@@ -60,9 +60,21 @@ mlir::Value GenericUnrollBase<ConcreteOp>::getValue(const mlir::ValueRange value
 // 1x3x1x16 with axis 1 will be split in three 1x1x1x16 values
 // 1x1x2x16 with axis 2 will be split in two 1x1x1x16 values
 // 1x3x1x16 with axis 2 won't be split and will return a vector with only one 1x3x1x16 element
+//
+// The location of each produced slice is derived from the consuming op being unrolled (consumerOp) plus
+// operandTag (which input is being split), the split axis and the chunk index. Deriving it from the
+// consumer rather than from val.getLoc() keeps the slice locations unique when the same value is shared
+// by more than one unrolled consumer - e.g. a grouped-quantization weight scale that is the
+// dequantization scale of two DynamicDequantize ops. Naming every slice after the shared value made the
+// low indices collide across consumers and tripped StopLocationVerifierPass ("Found N duplicated names
+// after full verification"). The axis tag is carried over from the existing "slice_d{axis}_{idx}"
+// naming: it disambiguates one value split along several axes, which is orthogonal to - and does not
+// cover - the shared-consumer case handled here.
 template <typename ConcreteOp>
 SmallVector<mlir::Value> GenericUnrollBase<ConcreteOp>::splitValue(const mlir::Value val, const int64_t axis,
-                                                                   mlir::PatternRewriter& rewriter) const {
+                                                                   mlir::PatternRewriter& rewriter,
+                                                                   mlir::Operation* consumerOp,
+                                                                   StringRef operandTag) const {
     const auto valShape = getShape(val);
     VPUX_THROW_UNLESS(axis < checked_cast<int64_t>(valShape.size()), "Cannot split shape {0} by axis {1}", valShape,
                       axis);
@@ -75,7 +87,7 @@ SmallVector<mlir::Value> GenericUnrollBase<ConcreteOp>::splitValue(const mlir::V
     const auto staticSizesAttr = getIntArrayAttr(rewriter.getContext(), staticSizes);
     SmallVector<mlir::Value> inputChunks;
     for (const auto& idx : irange(groups)) {
-        const auto loc = appendLoc(val.getLoc(), "slice_d{0}_{1}", axis, idx);
+        const auto loc = takeOpLoc(consumerOp, "{0}_slice_d{1}_{2}", operandTag, axis, idx);
         SmallVector<int64_t> offsets(valShape.size(), 0);
         offsets[axis] = idx;
         const auto offsetsAttr = getIntArrayAttr(rewriter.getContext(), offsets);
@@ -148,15 +160,17 @@ private:
 // IE.FakeQuantize with data = 1x1x8x16, in_low = in_high = 1x1x1x1, out_low = out_high = 1x1x1x16
 SmallVector<mlir::Value> UnrollFakeQuantize::splitInputs(IE::FakeQuantizeOp fqOp, const int64_t axis,
                                                          mlir::PatternRewriter& rewriter) const {
-    const auto data = splitValue(fqOp.getInput(), axis, rewriter);
-    const auto inLow = splitValue(fqOp.getInputLow(), axis, rewriter);
-    const auto inHigh = splitValue(fqOp.getInputHigh(), axis, rewriter);
-    const auto outLow = splitValue(fqOp.getOutputLow(), axis, rewriter);
-    const auto outHigh = splitValue(fqOp.getOutputHigh(), axis, rewriter);
+    const auto data = splitValue(fqOp.getInput(), axis, rewriter, fqOp, "data");
+    const auto inLow = splitValue(fqOp.getInputLow(), axis, rewriter, fqOp, "in_low");
+    const auto inHigh = splitValue(fqOp.getInputHigh(), axis, rewriter, fqOp, "in_high");
+    const auto outLow = splitValue(fqOp.getOutputLow(), axis, rewriter, fqOp, "out_low");
+    const auto outHigh = splitValue(fqOp.getOutputHigh(), axis, rewriter, fqOp, "out_high");
     SmallVector<mlir::Value> fqResults;
     const auto groups = data.size();
     for (const auto& idx : irange(groups)) {
-        const auto loc = appendLoc(fqOp.getLoc(), "slice_{0}", idx);
+        // One reduced FakeQuantize per chunk on the consumer's own location - unique by construction
+        // (unlike the shared-input operand slices above, which carry an operand tag to stay unique).
+        const auto loc = takeOpLoc(fqOp, "slice_{0}", idx);
         auto reducedFq = rewriter.create<IE::FakeQuantizeOp>(
                 loc, data[idx], getValue(inLow, idx), getValue(inHigh, idx), getValue(outLow, idx),
                 getValue(outHigh, idx), fqOp.getLevelsAttr(), fqOp.getLowFpTypeAttr(), fqOp.getAutoBroadcast());
@@ -183,18 +197,20 @@ private:
 
 SmallVector<mlir::Value> UnrollDynamicDequantize::splitInputs(IE::DynamicDequantizeOp origOp, const int64_t axis,
                                                               mlir::PatternRewriter& rewriter) const {
-    const auto input = splitValue(origOp.getInput(), axis, rewriter);
-    const auto scale = splitValue(origOp.getScale(), axis, rewriter);
+    const auto input = splitValue(origOp.getInput(), axis, rewriter, origOp, "input");
+    const auto scale = splitValue(origOp.getScale(), axis, rewriter, origOp, "scale");
     bool hasZeroPoint = false;
     SmallVector<mlir::Value> zeroPoint;
     if (origOp.getZp() != nullptr) {
         hasZeroPoint = true;
-        zeroPoint = splitValue(origOp.getZp(), axis, rewriter);
+        zeroPoint = splitValue(origOp.getZp(), axis, rewriter, origOp, "zp");
     }
     SmallVector<mlir::Value> deQuantizeResults;
     const auto groups = input.size();
     for (const auto& idx : irange(groups)) {
-        const auto loc = appendLoc(origOp.getLoc(), "slice_{0}", idx);
+        // One reduced DynamicDequantize per chunk on the consumer's own location - unique by construction
+        // (unlike the shared-input operand slices above, which carry an operand tag to stay unique).
+        const auto loc = takeOpLoc(origOp, "slice_{0}", idx);
         auto reduceDequantize = rewriter.create<IE::DynamicDequantizeOp>(
                 loc, getValue(input, idx), getValue(scale, idx), hasZeroPoint ? getValue(zeroPoint, idx) : nullptr,
                 origOp.getDstElemType());

--- a/tests/lit/NPU/dialect/IE/passes/unroll_group_quantize_shared_param_locations.mlir
+++ b/tests/lit/NPU/dialect/IE/passes/unroll_group_quantize_shared_param_locations.mlir
@@ -1,0 +1,65 @@
+//
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// RUN: vpux-opt --init-compiler="platform=%platform%" --unroll-group-quantize --mlir-print-debuginfo %s | FileCheck %s
+// REQUIRES: platform-NPU3720 || platform-NPU4000 || platform-NPU5010
+
+// Regression test for a location-uniqueness violation in UnrollGroupQuantize.
+//
+// One quantization scale (%SCALE) is the dequantization scale of TWO IE.DynamicDequantize ops - as happens
+// in grouped-INT4 attention projections, where the per-group scale feeds both the weight dequant and the
+// activation/matmul dequant. UnrollGroupQuantize unrolls each consumer and slices the shared scale in both.
+// Before the fix every slice was located after the shared scale value (".../slice_d{axis}_{idx}"), so the two
+// consumers produced byte-identical slice locations and StopLocationVerifierPass aborted the compile with
+// "Found N duplicated names after full verification". The fix locates each slice after its CONSUMING op plus
+// an operand tag, so the slices stay unique.
+//
+// Note: this is a minimal reduction - both consumers here unroll the shared scale along the same axis,
+// whereas the field case additionally unrolls them along different axes. The violation (slices of a shared
+// value named after that value) is identical either way; the axis count is incidental. The consumer ops
+// carry metadata-bearing fused locations to match importer-produced IR and exercise appendLoc's
+// preserve-existing-FusedLoc branch.
+
+!qElemType = !quant.uniform<u4:f16, 1.000000e+00>
+
+// CHECK-LABEL: @SharedScaleTwoConsumers
+func.func @SharedScaleTwoConsumers(%data0: tensor<2x1536x128x!qElemType>, %data1: tensor<2x1536x128x!qElemType>,
+                                   %scale: tensor<2x1536x1xf16>, %act0: tensor<1x256xf16>, %act1: tensor<1x256xf16>)
+        -> (tensor<1x1536xf16>, tensor<1x1536xf16>) {
+    %0 = IE.DynamicDequantize(%data0, %scale) {dstElemType = f16} : tensor<2x1536x128x!qElemType>, tensor<2x1536x1xf16> -> tensor<2x1536x128xf16> loc(fused<{name = "weight_dq", type = "DynamicDequantize"}>["weight_dq"])
+    %1 = IE.Transpose(%0) {order_value = affine_map<(d0, d1, d2) -> (d1, d0, d2)>} : tensor<2x1536x128xf16> -> tensor<1536x2x128xf16>
+    %2 = IE.AffineReshape(%1) {dim_mapping = [[0], [1], [1]], shape_value = [1536, 256]} : tensor<1536x2x128xf16> -> tensor<1536x256xf16>
+    %3 = IE.FullyConnected(%act0, %2) : tensor<1x256xf16>, tensor<1536x256xf16> -> tensor<1x1536xf16>
+
+    %4 = IE.DynamicDequantize(%data1, %scale) {dstElemType = f16} : tensor<2x1536x128x!qElemType>, tensor<2x1536x1xf16> -> tensor<2x1536x128xf16> loc(fused<{name = "matmul_dq", type = "DynamicDequantize"}>["matmul_dq"])
+    %5 = IE.Transpose(%4) {order_value = affine_map<(d0, d1, d2) -> (d1, d0, d2)>} : tensor<2x1536x128xf16> -> tensor<1536x2x128xf16>
+    %6 = IE.AffineReshape(%5) {dim_mapping = [[0], [1], [1]], shape_value = [1536, 256]} : tensor<1536x2x128xf16> -> tensor<1536x256xf16>
+    %7 = IE.FullyConnected(%act1, %6) : tensor<1x256xf16>, tensor<1536x256xf16> -> tensor<1x1536xf16>
+
+    return %3, %7 : tensor<1x1536xf16>, tensor<1x1536xf16>
+
+    // Bind each shared-scale (and data) slice to its IE.Slice op, then assert the captured location resolves
+    // to a fused loc rooted at the CONSUMING op + an operand tag. The two consumers' "scale_slice_*" (and
+    // "input_slice_*") therefore resolve to distinct locations (weight_dq vs matmul_dq roots), which is the
+    // invariant the fix restores. Pre-fix the suffix is the un-tagged "slice_d{axis}_0" rooted at the shared
+    // scale, so the "scale_slice_*"/"input_slice_*" alias definitions below are absent and the test fails.
+
+    // Consumer A ("weight_dq"): its data slice then its shared-scale slice.
+    // CHECK:     IE.Slice %arg0 [0, 0, 0] [1, 1536, 128] {{.*}} loc([[A_INPUT0:#.+]])
+    // CHECK:     IE.Slice %arg2 [0, 0, 0] [1, 1536, 1] {{.*}} loc([[A_SCALE0:#.+]])
+    // Consumer B ("matmul_dq"): its data slice then its shared-scale slice.
+    // CHECK:     IE.Slice %arg1 [0, 0, 0] [1, 1536, 128] {{.*}} loc([[B_INPUT0:#.+]])
+    // CHECK:     IE.Slice %arg2 [0, 0, 0] [1, 1536, 1] {{.*}} loc([[B_SCALE0:#.+]])
+
+    // CHECK-DAG: [[WEIGHT_DQ:#.+]] = loc("weight_dq")
+    // CHECK-DAG: [[MATMUL_DQ:#.+]] = loc("matmul_dq")
+    // CHECK-DAG: [[INPUT_SLICE0:#.+]] = loc("input_slice_d{{[0-9]+}}_0")
+    // CHECK-DAG: [[SCALE_SLICE0:#.+]] = loc("scale_slice_d{{[0-9]+}}_0")
+
+    // CHECK-DAG: [[A_INPUT0]] = loc(fused<{{.*}}>{{\[}}[[WEIGHT_DQ]], [[INPUT_SLICE0]]])
+    // CHECK-DAG: [[A_SCALE0]] = loc(fused<{{.*}}>{{\[}}[[WEIGHT_DQ]], [[SCALE_SLICE0]]])
+    // CHECK-DAG: [[B_INPUT0]] = loc(fused<{{.*}}>{{\[}}[[MATMUL_DQ]], [[INPUT_SLICE0]]])
+    // CHECK-DAG: [[B_SCALE0]] = loc(fused<{{.*}}>{{\[}}[[MATMUL_DQ]], [[SCALE_SLICE0]]])
+}


### PR DESCRIPTION
### Details:

**Problem.** `UnrollGroupQuantize` (via the shared `GenericUnrollBase::splitValue`) names each
unrolled slice after the *value being split* — currently
`appendLoc(val.getLoc(), "slice_d{axis}_{idx}")`. When a single value feeds more than one
unrolled consumer — e.g. a grouped-INT4 per-group scale that is the dequantization scale of
**both** the weight `DynamicDequantize` and the activation/matmul `DynamicDequantize` — the
slices of that shared value get byte-identical locations across the two consumers, which
violates the location-uniqueness invariant `StopLocationVerifierPass` enforces.

This still reproduces on current `develop`. Running the pass on the reduction added by this PR,
the two consumers' slices of the same shared scale resolve to the *same* location:

```mlir
%2  = IE.Slice %arg2 [0, 0, 0] [1, 1536, 1] ... loc(#loc28)   // consumer "weight_dq"
%12 = IE.Slice %arg2 [0, 0, 0] [1, 1536, 1] ... loc(#loc28)   // consumer "matmul_dq"
#loc28 = loc(fused[#loc7, #loc10])
#loc10 = loc("slice_d0_0")
```

The `d{axis}` component added in UD2026.28 does not separate this case: both consumers unroll the
shared value along the same axis, so the axis tag is identical on both sides.

**Fix.** Derive each slice's location from the *consuming op* plus an operand tag, keeping the
existing axis and chunk index — `takeOpLoc(consumerOp, "{operandTag}_slice_d{axis}_{idx}")`.
Slices of a shared value then stay unique because they are rooted at the (distinct) consumers,
while the axis tag continues to do its own job of separating one value split along several axes.
All `splitValue` call sites are updated to pass the consumer + operand tag. The per-chunk reduced
ops (FakeQuantize / DynamicDequantize) keep their consumer-rooted `slice_{idx}` locations, which
are already unique by construction.

With the fix, the same two slices become:

```mlir
#loc30 = loc(fused<{name = "weight_dq",  ...}>[#loc10, #loc13])
#loc37 = loc(fused<{name = "matmul_dq", ...}>[#loc21, #loc13])
```

**Test.** New LIT test
`tests/lit/NPU/dialect/IE/passes/unroll_group_quantize_shared_param_locations.mlir`: a shared
scale feeding two `DynamicDequantize` consumers; asserts each consumer's slices resolve to a
fused location rooted at that consumer + operand tag. It fails on unpatched `develop` and passes
with this change.

### Validation:

Manual validation — the automatic checks on this PR have never run (fork PRs appear to require a
maintainer to approve workflows). Per CONTRIBUTING's allowance for manual results:

- **LIT**, using the same invocation as the test's RUN line:
  `vpux-opt --init-compiler="platform=NPU4000" --unroll-group-quantize --mlir-print-debuginfo | FileCheck`
  - unpatched `develop`: **FAIL** (FileCheck exit 1)
  - with this change: **PASS**
- **Built from source** on Windows: OpenVINO at `4089686065a245d648cdd2b99c31884f53cb7a5e` (the
  commit pinned by `validation/openvino_config.json` on `develop`), npu_compiler at this PR's
  head, RelWithDebInfo, MSVC 19.44, Ninja. Hardware: Intel Core Ultra 7 258V (Lunar Lake),
  NPU 4000.
- **End-to-end**, for completeness and as a correction — see below.

### Correction to this PR's original claim:

This PR originally reported that it unblocked an end-to-end compile of Qwen3-0.6B grouped-INT4
via the NPUW-LLM path, which had been aborting with
`StopLocationVerifierPass Pass failed : Found 40 duplicated names after full verification`.

**That is no longer true on current `develop`, and I am withdrawing it.** I re-ran the original
reproducer (same model, same harness, same NPU_USE_NPUW/NPUW_LLM configuration) against
`develop` with and without this change. The two runs are equivalent: neither reports duplicated
names, both proceed past `StopLocationVerifierPass`, and both fail later at the same place —
`UnrollDistributedOps Pass failed : Can't convert 20 Bit to Byte`
(`vpux/utils/core/mem_size.hpp:128`), which is the sub-byte lowering limitation on this
configuration, not something this PR addresses.

So something between UD2026.20 and UD2026.28 changed the pipeline such that this particular model
no longer reaches the colliding configuration. I did not trace which change.

**What this PR is now:** a fix for a location-uniqueness violation that demonstrably still exists
in `develop`, plus a regression test that fails without it — not a fix for a currently-observable
compile blocker. If you would rather address the invariant differently, it can be reshaped or
closed.

### Tickets:

- Related context: openvinotoolkit/openvino#34450, and #265 / #266 (both superseded by this PR).

### AI Assistance:

- AI assistance used: yes.
- Tooling: Claude Code.
- What was AI-assisted: the location-uniqueness analysis, the `splitValue` refactor, the LIT
  regression test, the rebase conflict resolution, and the before/after experiment design.
- Human validation: I reviewed and approved the change before submitting it. All results above were
  produced by building both configurations from source and running them on real hardware
  (Intel Core Ultra 7 258V / NPU 4000). The before/after comparison was a single-variable control
  — only `unroll_group_quantize.cpp` was reverted, in the same build tree with identical flags —
  and was checked to have actually rebuilt (differing binaries) before the results were trusted.



