### PR TITLE
vpux_utils: add missing <cstdlib> for std::getenv

### DIFF
--- a/src/vpux_utils/src/core/developer_build_utils.cpp
+++ b/src/vpux_utils/src/core/developer_build_utils.cpp
@@ -5,6 +5,8 @@
 
 #include "vpux/utils/core/developer_build_utils.hpp"
 
+#include <cstdlib>
+
 using namespace vpux;
 
 void vpux::parseEnv(StringRef envVarName, std::string& var) {


### PR DESCRIPTION
## Summary

`src/vpux_utils/src/core/developer_build_utils.cpp` calls `std::getenv()` twice but
includes only its own header. The declaration has been arriving indirectly, through
the `<llvm/ADT/StringRef.h>` chain pulled in by `developer_build_utils.hpp`.

LLVM 22's libc++ removes non-essential transitive includes, and with
`-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES=1` that indirect path disappears:

```
developer_build_utils.cpp:11:31: error: no member named 'getenv' in namespace 'std'
   11 |     if (const auto env = std::getenv(envVarName.data())) {
      |                               ^~~~~~
developer_build_utils.cpp:17:31: error: no member named 'getenv' in namespace 'std'
2 errors generated.
```

`std::getenv` is declared by `<cstdlib>`, so this adds that include. One line, no
functional change.

Verified with clang 22.1.8 + libc++ on current `develop`:

| | result |
| --- | --- |
| `-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES=1`, before | 2 errors (above) |
| `-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES=1`, after | clean |
| without the flag (control), before and after | clean |

Found while building ChromeOS against an LLVM 22 toolchain, where the same file
needed the same include at the pinned `npu_ud_2024_44_rc1` revision.

## JIRA ticket

* *N/A* — external contribution

## Target Platform For Release Notes

- [ ] NPU37XX
- [ ] NPU40XX
- [ ] NPU50XX
- [x] NONE (Not included in release notes)

## Classification of this Pull Request

- [x] Maintenance
- [ ] BUG
- [ ] Feature

## Related PRs

* [openvinotoolkit/openvino#37236](https://github.com/openvinotoolkit/openvino/pull/37236) —
  the same class of fix in the main OpenVINO repository, merged. No dependency between
  the two; listed for context.

## AI Assistance

* *AI assistance used: yes*
