### PR TITLE
Cache sorted async dependency vectors

### DIFF
--- a/src/vpux_compiler/include/vpux/compiler/core/async_deps_info.hpp
+++ b/src/vpux_compiler/include/vpux/compiler/core/async_deps_info.hpp
@@ -16,6 +16,8 @@
 
 #include <llvm/ADT/DenseSet.h>
 
+#include <optional>
+
 namespace vpux {
 
 class AsyncDepsInfo final {
@@ -40,8 +42,13 @@ public:
     void verifyAcyclic() const;
 
 private:
+    using DepsMap = SmallVector<llvm::DenseSet<size_t>>;
+    using DepsVecCache = SmallVector<std::optional<SmallVector<size_t>>>;
+
     void setIndex(mlir::async::ExecuteOp execOp, uint64_t index);
     SmallVector<size_t> getDepsVec(const llvm::DenseSet<size_t>& deps) const;
+    const SmallVector<size_t>& getCachedDepsVec(size_t opIdx, const DepsMap& depsMap, DepsVecCache& depsVecCache) const;
+    static void invalidateDepsVecCacheEntry(DepsVecCache& depsVecCache, size_t opIdx);
     bool hasCycle() const;
 
 private:
@@ -56,8 +63,14 @@ private:
     SmallVector<mlir::async::ExecuteOp> _allExecOps;
 
     // indexOf(mlir::async::ExecuteOp) 'depends on' [ indexOf(mlir::async::ExecuteOp)... ].
-    SmallVector<llvm::DenseSet<size_t>> _depsMap;
-    SmallVector<llvm::DenseSet<size_t>> _consumerMap;
+    DepsMap _depsMap;
+    DepsMap _consumerMap;
+
+    // getOpDeps() and getConsumerOps() are called repeatedly by the schedulers. Keep the
+    // deterministically sorted representation and invalidate only entries whose set changes.
+    mutable DepsVecCache _depsVecCache;
+    mutable DepsVecCache _consumerVecCache;
+
     size_t _execOpCount = 0;
 };
 

--- a/src/vpux_compiler/src/core/async_deps_info.cpp
+++ b/src/vpux_compiler/src/core/async_deps_info.cpp
@@ -133,6 +133,25 @@ SmallVector<size_t> vpux::AsyncDepsInfo::getDepsVec(const llvm::DenseSet<size_t>
     return vec;
 }
 
+const SmallVector<size_t>& vpux::AsyncDepsInfo::getCachedDepsVec(size_t opIdx, const DepsMap& depsMap,
+                                                                 DepsVecCache& depsVecCache) const {
+    if (depsVecCache.size() < depsMap.size()) {
+        depsVecCache.resize(depsMap.size());
+    }
+
+    auto& cachedDeps = depsVecCache[opIdx];
+    if (!cachedDeps.has_value()) {
+        cachedDeps.emplace(getDepsVec(depsMap[opIdx]));
+    }
+    return cachedDeps.value();
+}
+
+void vpux::AsyncDepsInfo::invalidateDepsVecCacheEntry(DepsVecCache& depsVecCache, size_t opIdx) {
+    if (opIdx < depsVecCache.size()) {
+        depsVecCache[opIdx].reset();
+    }
+}
+
 uint32_t vpux::AsyncDepsInfo::getIndex(mlir::async::ExecuteOp execOp) const {
     const auto attr = execOp->getAttrOfType<mlir::IntegerAttr>(_indexAttrName);
     VPUX_THROW_UNLESS(attr != nullptr, "Attribute '{0}' was not set for '{1}' operation at '{2}'", _indexAttrName,
@@ -200,7 +219,7 @@ void vpux::AsyncDepsInfo::addExecOp(mlir::async::ExecuteOp execOp) {
         _log.trace("It has a dependency from other 'async.execute' Operation at '{0}'", argExecOp->getLoc());
 
         const auto argExecInd = getIndex(argExecOp);
-        _depsMap[execInd].insert(argExecInd);
+        addDependency(argExecInd, execInd);
     }
 
     _log = _log.unnest();
@@ -217,10 +236,17 @@ void vpux::AsyncDepsInfo::addDependency(mlir::async::ExecuteOp from, mlir::async
 }
 
 void vpux::AsyncDepsInfo::addDependency(size_t fromOpIdx, size_t toOpIdx) {
-    _depsMap[toOpIdx].insert(fromOpIdx);
+    const auto depsInsertion = _depsMap[toOpIdx].insert(fromOpIdx);
+    if (depsInsertion.second) {
+        invalidateDepsVecCacheEntry(_depsVecCache, toOpIdx);
+    }
+
     if (!_consumerMap.empty()) {
         // also update consumer map if build
-        _consumerMap[fromOpIdx].insert(toOpIdx);
+        const auto consumerInsertion = _consumerMap[fromOpIdx].insert(toOpIdx);
+        if (consumerInsertion.second) {
+            invalidateDepsVecCacheEntry(_consumerVecCache, fromOpIdx);
+        }
     }
 }
 
@@ -272,9 +298,10 @@ void vpux::AsyncDepsInfo::optimizeDepsMap() {
         }
     }
 
+    _depsVecCache.clear();
+
     if (!_consumerMap.empty()) {
         // re-build consumer map using new deps map if build
-        _consumerMap.clear();
         buildConsMap();
     }
 }
@@ -284,7 +311,9 @@ void vpux::AsyncDepsInfo::optimizeDepsMap() {
 //
 
 void vpux::AsyncDepsInfo::buildConsMap() {
+    _consumerMap.clear();
     _consumerMap.resize(_depsMap.size());
+    _consumerVecCache.clear();
 
     for (size_t idx = 0; idx < _depsMap.size(); idx++) {
         for (auto bit : _depsMap[idx]) {
@@ -305,7 +334,7 @@ void vpux::AsyncDepsInfo::updateTokenDependencies() {
         _log.trace("Process 'async.execute' Operation at '{0}'", execOpIt->getLoc());
 
         const auto execInd = getIndex(*execOpIt);
-        const auto execDeps = getDepsVec(_depsMap[execInd]);
+        const auto execDeps = getOpDeps(execInd);
 
         SmallVector<mlir::Value> depsVec;
         for (auto depInd : execDeps) {
@@ -346,13 +375,13 @@ void vpux::AsyncDepsInfo::preAllocateForNewOps(size_t numOfNewOps) {
 
 const llvm::SmallVector<size_t> vpux::AsyncDepsInfo::getOpDeps(size_t opIdx) const {
     VPUX_THROW_WHEN(opIdx >= _execOpCount, "Invalid index '{0}' for _depsMap", opIdx);
-    return getDepsVec(_depsMap[opIdx]);
+    return getCachedDepsVec(opIdx, _depsMap, _depsVecCache);
 }
 
 const llvm::SmallVector<size_t> vpux::AsyncDepsInfo::getConsumerOps(size_t opIdx) const {
     VPUX_THROW_WHEN(_consumerMap.empty(), "Consumer map was not build");
     VPUX_THROW_WHEN(opIdx >= _execOpCount, "Invalid index '{0}' for _consumerMap", opIdx);
-    return getDepsVec(_consumerMap[opIdx]);
+    return getCachedDepsVec(opIdx, _consumerMap, _consumerVecCache);
 }
 
 std::unordered_map<size_t, size_t> vpux::AsyncDepsInfo::calculateOpInDegreeTable() const {

--- a/tests/unit/vpux_compiler/core/async_deps_info_tests.cpp
+++ b/tests/unit/vpux_compiler/core/async_deps_info_tests.cpp
@@ -77,6 +77,11 @@ TEST_F(MLIR_AsyncDepsInfo, AddDependencySCSPWithCircle) {
     auto op2Consumers = info.getConsumerOps(2);
     EXPECT_EQ(op2Consumers.size(), 0);
 
+    // Prime the dependency cache before adding a new edge.
+    auto op2Deps = info.getOpDeps(2);
+    ASSERT_EQ(op2Deps.size(), 1);
+    EXPECT_EQ(op2Deps[0], 1);
+
     // Calling addDependency twice should not duplicate entries
     info.addDependency(0, 2);
     info.addDependency(0, 2);
@@ -86,9 +91,9 @@ TEST_F(MLIR_AsyncDepsInfo, AddDependencySCSPWithCircle) {
     EXPECT_TRUE(std::find(op0ConsumersAfter.begin(), op0ConsumersAfter.end(), 2) != op0ConsumersAfter.end());
 
     auto op2DepsAfter = info.getOpDeps(2);
-    EXPECT_EQ(op2DepsAfter.size(), 2);
-    EXPECT_TRUE(std::find(op2DepsAfter.begin(), op2DepsAfter.end(), 0) != op2DepsAfter.end());
-    EXPECT_TRUE(std::find(op2DepsAfter.begin(), op2DepsAfter.end(), 1) != op2DepsAfter.end());
+    ASSERT_EQ(op2DepsAfter.size(), 2);
+    EXPECT_EQ(op2DepsAfter[0], 0);
+    EXPECT_EQ(op2DepsAfter[1], 1);
 
     // Introduce a cycle and verifyAcyclic should throw
     info.addDependency(2, 0);
@@ -222,10 +227,15 @@ TEST_F(MLIR_AsyncDepsInfo, OptimizeDepsMap) {
     ASSERT_TRUE(func != nullptr);
 
     vpux::AsyncDepsInfo info(func);
+    info.buildConsMap();
 
     // Before optimization: op2 depends on both op0 and op1
     auto op2DepsBefore = info.getOpDeps(2);
     EXPECT_EQ(op2DepsBefore.size(), 2);
+
+    // Prime the consumer cache before optimizeDepsMap rebuilds the consumer map.
+    auto op0ConsumersBefore = info.getConsumerOps(0);
+    EXPECT_EQ(op0ConsumersBefore.size(), 2);
 
     // Optimize: since op1 depends on op0, and op2 depends on both,
     // the dependency from op2 to op0 is redundant
@@ -235,6 +245,10 @@ TEST_F(MLIR_AsyncDepsInfo, OptimizeDepsMap) {
     auto op2DepsAfter = info.getOpDeps(2);
     EXPECT_EQ(op2DepsAfter.size(), 1);
     EXPECT_EQ(op2DepsAfter[0], 1);
+
+    auto op0ConsumersAfter = info.getConsumerOps(0);
+    EXPECT_EQ(op0ConsumersAfter.size(), 1);
+    EXPECT_EQ(op0ConsumersAfter[0], 1);
 }
 
 TEST_F(MLIR_AsyncDepsInfo, CalculateInOutDegree) {
@@ -314,6 +328,11 @@ TEST_F(MLIR_AsyncDepsInfo, InsertNewExecOp) {
     ASSERT_TRUE(func != nullptr);
 
     vpux::AsyncDepsInfo info(func);
+    info.buildConsMap();
+
+    // Prime both caches before extending the maps.
+    EXPECT_TRUE(info.getOpDeps(0).empty());
+    EXPECT_TRUE(info.getConsumerOps(0).empty());
 
     // Initial count should be 1
     EXPECT_EQ(info.getExecOpCount(), 1);
@@ -326,9 +345,9 @@ TEST_F(MLIR_AsyncDepsInfo, InsertNewExecOp) {
     auto asyncValueType = mlir::async::ValueType::get(memrefType);
     auto tokenType = builder.getType<mlir::async::TokenType>();
 
-    auto newExecOp =
-            builder.create<mlir::async::ExecuteOp>(builder.getUnknownLoc(), mlir::TypeRange{tokenType, asyncValueType},
-                                                   mlir::ValueRange{}, mlir::ValueRange{});
+    auto newExecOp = builder.create<mlir::async::ExecuteOp>(
+            builder.getUnknownLoc(), mlir::TypeRange{tokenType, asyncValueType},
+            mlir::ValueRange{info.getExecuteOpAtIndex(0).getToken()}, mlir::ValueRange{});
 
     auto& bodyBlock = newExecOp.getBodyRegion().emplaceBlock();
     builder.setInsertionPointToStart(&bodyBlock);
@@ -344,4 +363,12 @@ TEST_F(MLIR_AsyncDepsInfo, InsertNewExecOp) {
 
     auto retrievedOp = info.getExecuteOpAtIndex(newIdx);
     EXPECT_EQ(retrievedOp, newExecOp);
+
+    auto newOpDeps = info.getOpDeps(newIdx);
+    ASSERT_EQ(newOpDeps.size(), 1);
+    EXPECT_EQ(newOpDeps[0], 0);
+
+    auto op0Consumers = info.getConsumerOps(0);
+    ASSERT_EQ(op0Consumers.size(), 1);
+    EXPECT_EQ(op0Consumers[0], newIdx);
 }


### PR DESCRIPTION
## Summary

`AsyncDepsInfo::getOpDeps()` and `getConsumerOps()` materialize and sort a `DenseSet` on every call. The feasible-allocation and prefetch schedulers query many stable dependency sets repeatedly, causing the same vectors to be reconstructed and sorted many times.

This change:

- Lazily caches sorted dependency and consumer vectors
- Invalidates only entries whose underlying set changes
- Clears the relevant caches when dependency maps are optimized or consumer maps are rebuilt
- Routes initial dependency insertion through the same cache-invalidating path
- Preserves the existing deterministic, sorted, by-value public API

## Performance

Measured on an Intel NPU 5010 using OpenVINO 2026.3 and Qwen2.5-7B INT8.

Each result used one excluded warmup followed by three adjacent baseline/candidate pairs. Arm ordering alternated between repeats, and UMD caching was bypassed.

| Context window | Baseline median | Candidate median | Median paired improvement |
|---:|---:|---:|---:|
| 1024 | 351.715s | 339.112s | 3.583% |
| 2048 | 241.834s | 232.774s | 3.746% |
| 4096 | 253.098s | 243.770s | 3.678% |
| 8192 | 306.146s | 297.526s | 2.816% |

The candidate won all 12 measured pairs. The geometric-mean speedup was **1.0359x**.

### Profiling

A gated W2048 CPU profile measured:

- `qsort`-family CPU time: 7.960s → 0.747s, a **90.6% reduction**
- `FeasibleAllocation`: 18.471s → 7.381s, a **60.0% reduction**
- Full `compile_model`: 242.647s → 234.255s, a **3.46% improvement**

The additional CPU saving beyond visible `qsort` samples is consistent with avoiding repeated `DenseSet` traversal, vector construction, and allocation.

## Correctness and validation

- `MLIR_AsyncDepsInfo.*`: 5/5 tests passed
- Complete `npuUnitTests`: 6004/6004 tests passed; 31 disabled
- `clang-format` 18.1.8 passed
- `git diff --check` passed
- A diagnostic Qwen2.5-7B W2048 compile recomputed and sorted every cached lookup and asserted equality; compilation completed successfully
- The signed PR commit `4c2217bf4` has the same source tree (`a8df19163767`) as the tested commit, so the measured candidate code and binary are unchanged

## Memory tradeoff

The cache retains sorted vectors in addition to the existing dependency sets.

Paired peak-RSS results were noisy, with median changes ranging from approximately −1 MiB to +67 MiB depending on context window. The largest observed outlier was +274 MiB against an approximately 9.2 GiB process peak.

## JIRA ticket

Fixes #342

## Target Platform For Release Notes

- [ ] NPU37XX
- [ ] NPU40XX
- [x] NPU50XX
- [ ] NONE (Not included in release notes)

The implementation is architecture-independent, but hardware performance validation was performed on NPU50XX.

## Classification of this Pull Request

- [x] Maintenance
- [ ] BUG
- [ ] Feature

## Related PRs

None.