### PR TITLE
Cache sorted async dependency vectors

### DIFF
--- a/src/vpux_compiler/include/vpux/compiler/core/async_deps_info.hpp
+++ b/src/vpux_compiler/include/vpux/compiler/core/async_deps_info.hpp
@@ -16,6 +16,8 @@
 
 #include <llvm/ADT/DenseSet.h>
 
+#include <optional>
+
 namespace vpux {
 
 class AsyncDepsInfo final {
@@ -40,8 +42,13 @@ public:
     void verifyAcyclic() const;
 
 private:
+    using DepsMap = SmallVector<llvm::DenseSet<size_t>>;
+    using DepsVecCache = SmallVector<std::optional<SmallVector<size_t>>>;
+
     void setIndex(mlir::async::ExecuteOp execOp, uint64_t index);
     SmallVector<size_t> getDepsVec(const llvm::DenseSet<size_t>& deps) const;
+    const SmallVector<size_t>& getCachedDepsVec(size_t opIdx, const DepsMap& depsMap, DepsVecCache& depsVecCache) const;
+    static void invalidateDepsVecCacheEntry(DepsVecCache& depsVecCache, size_t opIdx);
     bool hasCycle() const;
 
 private:
@@ -56,8 +63,14 @@ private:
     SmallVector<mlir::async::ExecuteOp> _allExecOps;
 
     // indexOf(mlir::async::ExecuteOp) 'depends on' [ indexOf(mlir::async::ExecuteOp)... ].
-    SmallVector<llvm::DenseSet<size_t>> _depsMap;
-    SmallVector<llvm::DenseSet<size_t>> _consumerMap;
+    DepsMap _depsMap;
+    DepsMap _consumerMap;
+
+    // getOpDeps() and getConsumerOps() are called repeatedly by the schedulers. Keep the
+    // deterministically sorted representation and invalidate only entries whose set changes.
+    mutable DepsVecCache _depsVecCache;
+    mutable DepsVecCache _consumerVecCache;
+
     size_t _execOpCount = 0;
 };
 

--- a/src/vpux_compiler/src/core/async_deps_info.cpp
+++ b/src/vpux_compiler/src/core/async_deps_info.cpp
@@ -133,6 +133,25 @@ SmallVector<size_t> vpux::AsyncDepsInfo::getDepsVec(const llvm::DenseSet<size_t>
     return vec;
 }
 
+const SmallVector<size_t>& vpux::AsyncDepsInfo::getCachedDepsVec(size_t opIdx, const DepsMap& depsMap,
+                                                                 DepsVecCache& depsVecCache) const {
+    if (depsVecCache.size() < depsMap.size()) {
+        depsVecCache.resize(depsMap.size());
+    }
+
+    auto& cachedDeps = depsVecCache[opIdx];
+    if (!cachedDeps.has_value()) {
+        cachedDeps.emplace(getDepsVec(depsMap[opIdx]));
+    }
+    return cachedDeps.value();
+}
+
+void vpux::AsyncDepsInfo::invalidateDepsVecCacheEntry(DepsVecCache& depsVecCache, size_t opIdx) {
+    if (opIdx < depsVecCache.size()) {
+        depsVecCache[opIdx].reset();
+    }
+}
+
 uint32_t vpux::AsyncDepsInfo::getIndex(mlir::async::ExecuteOp execOp) const {
     const auto attr = execOp->getAttrOfType<mlir::IntegerAttr>(_indexAttrName);
     VPUX_THROW_UNLESS(attr != nullptr, "Attribute '{0}' was not set for '{1}' operation at '{2}'", _indexAttrName,
@@ -200,7 +219,7 @@ void vpux::AsyncDepsInfo::addExecOp(mlir::async::ExecuteOp execOp) {
         _log.trace("It has a dependency from other 'async.execute' Operation at '{0}'", argExecOp->getLoc());
 
         const auto argExecInd = getIndex(argExecOp);
-        _depsMap[execInd].insert(argExecInd);
+        addDependency(argExecInd, execInd);
     }
 
     _log = _log.unnest();
@@ -217,10 +236,17 @@ void vpux::AsyncDepsInfo::addDependency(mlir::async::ExecuteOp from, mlir::async
 }
 
 void vpux::AsyncDepsInfo::addDependency(size_t fromOpIdx, size_t toOpIdx) {
-    _depsMap[toOpIdx].insert(fromOpIdx);
+    const auto depsInsertion = _depsMap[toOpIdx].insert(fromOpIdx);
+    if (depsInsertion.second) {
+        invalidateDepsVecCacheEntry(_depsVecCache, toOpIdx);
+    }
+
     if (!_consumerMap.empty()) {
         // also update consumer map if build
-        _consumerMap[fromOpIdx].insert(toOpIdx);
+        const auto consumerInsertion = _consumerMap[fromOpIdx].insert(toOpIdx);
+        if (consumerInsertion.second) {
+            invalidateDepsVecCacheEntry(_consumerVecCache, fromOpIdx);
+        }
     }
 }
 
@@ -272,9 +298,10 @@ void vpux::AsyncDepsInfo::optimizeDepsMap() {
         }
     }
 
+    _depsVecCache.clear();
+
     if (!_consumerMap.empty()) {
         // re-build consumer map using new deps map if build
-        _consumerMap.clear();
         buildConsMap();
     }
 }
@@ -284,7 +311,9 @@ void vpux::AsyncDepsInfo::optimizeDepsMap() {
 //
 
 void vpux::AsyncDepsInfo::buildConsMap() {
+    _consumerMap.clear();
     _consumerMap.resize(_depsMap.size());
+    _consumerVecCache.clear();
 
     for (size_t idx = 0; idx < _depsMap.size(); idx++) {
         for (auto bit : _depsMap[idx]) {
@@ -305,7 +334,7 @@ void vpux::AsyncDepsInfo::updateTokenDependencies() {
         _log.trace("Process 'async.execute' Operation at '{0}'", execOpIt->getLoc());
 
         const auto execInd = getIndex(*execOpIt);
-        const auto execDeps = getDepsVec(_depsMap[execInd]);
+        const auto execDeps = getOpDeps(execInd);
 
         SmallVector<mlir::Value> depsVec;
         for (auto depInd : execDeps) {
@@ -346,13 +375,13 @@ void vpux::AsyncDepsInfo::preAllocateForNewOps(size_t numOfNewOps) {
 
 const llvm::SmallVector<size_t> vpux::AsyncDepsInfo::getOpDeps(size_t opIdx) const {
     VPUX_THROW_WHEN(opIdx >= _execOpCount, "Invalid index '{0}' for _depsMap", opIdx);
-    return getDepsVec(_depsMap[opIdx]);
+    return getCachedDepsVec(opIdx, _depsMap, _depsVecCache);
 }
 
 const llvm::SmallVector<size_t> vpux::AsyncDepsInfo::getConsumerOps(size_t opIdx) const {
     VPUX_THROW_WHEN(_consumerMap.empty(), "Consumer map was not build");
     VPUX_THROW_WHEN(opIdx >= _execOpCount, "Invalid index '{0}' for _consumerMap", opIdx);
-    return getDepsVec(_consumerMap[opIdx]);
+    return getCachedDepsVec(opIdx, _consumerMap, _consumerVecCache);
 }
 
 std::unordered_map<size_t, size_t> vpux::AsyncDepsInfo::calculateOpInDegreeTable() const {

--- a/tests/unit/vpux_compiler/core/async_deps_info_tests.cpp
+++ b/tests/unit/vpux_compiler/core/async_deps_info_tests.cpp
@@ -77,6 +77,11 @@ TEST_F(MLIR_AsyncDepsInfo, AddDependencySCSPWithCircle) {
     auto op2Consumers = info.getConsumerOps(2);
     EXPECT_EQ(op2Consumers.size(), 0);
 
+    // Prime the dependency cache before adding a new edge.
+    auto op2Deps = info.getOpDeps(2);
+    ASSERT_EQ(op2Deps.size(), 1);
+    EXPECT_EQ(op2Deps[0], 1);
+
     // Calling addDependency twice should not duplicate entries
     info.addDependency(0, 2);
     info.addDependency(0, 2);
@@ -86,9 +91,9 @@ TEST_F(MLIR_AsyncDepsInfo, AddDependencySCSPWithCircle) {
     EXPECT_TRUE(std::find(op0ConsumersAfter.begin(), op0ConsumersAfter.end(), 2) != op0ConsumersAfter.end());
 
     auto op2DepsAfter = info.getOpDeps(2);
-    EXPECT_EQ(op2DepsAfter.size(), 2);
-    EXPECT_TRUE(std::find(op2DepsAfter.begin(), op2DepsAfter.end(), 0) != op2DepsAfter.end());
-    EXPECT_TRUE(std::find(op2DepsAfter.begin(), op2DepsAfter.end(), 1) != op2DepsAfter.end());
+    ASSERT_EQ(op2DepsAfter.size(), 2);
+    EXPECT_EQ(op2DepsAfter[0], 0);
+    EXPECT_EQ(op2DepsAfter[1], 1);
 
     // Introduce a cycle and verifyAcyclic should throw
     info.addDependency(2, 0);
@@ -149,17 +154,17 @@ TEST_F(MLIR_AsyncDepsInfo, AddDependencyMCMP) {
     // One producer feeding multiple consumers
     // op0 feeds op2, op3, and op4
     auto op0Consumers = info.getConsumerOps(0);
-    EXPECT_EQ(op0Consumers.size(), 3);
-    EXPECT_TRUE(std::find(op0Consumers.begin(), op0Consumers.end(), 2) != op0Consumers.end());
-    EXPECT_TRUE(std::find(op0Consumers.begin(), op0Consumers.end(), 3) != op0Consumers.end());
-    EXPECT_TRUE(std::find(op0Consumers.begin(), op0Consumers.end(), 4) != op0Consumers.end());
+    ASSERT_EQ(op0Consumers.size(), 3);
+    EXPECT_EQ(op0Consumers[0], 2);
+    EXPECT_EQ(op0Consumers[1], 3);
+    EXPECT_EQ(op0Consumers[2], 4);
 
     // Multiple producers feeding one consumer
     // op4 consumes from both op0 and op1
     auto op4Deps = info.getOpDeps(4);
-    EXPECT_EQ(op4Deps.size(), 2);
-    EXPECT_TRUE(std::find(op4Deps.begin(), op4Deps.end(), 0) != op4Deps.end());
-    EXPECT_TRUE(std::find(op4Deps.begin(), op4Deps.end(), 1) != op4Deps.end());
+    ASSERT_EQ(op4Deps.size(), 2);
+    EXPECT_EQ(op4Deps[0], 0);
+    EXPECT_EQ(op4Deps[1], 1);
 
     // op1 has one consumer (op4)
     auto op1Consumers = info.getConsumerOps(1);
@@ -168,20 +173,34 @@ TEST_F(MLIR_AsyncDepsInfo, AddDependencyMCMP) {
 
     // Add new dependency from op1 to op2 and verify consumer map is updated
     info.addDependency(1, 2);
+    info.addDependency(1, 2);
 
     auto op1ConsumersAfter = info.getConsumerOps(1);
-    EXPECT_EQ(op1ConsumersAfter.size(), 2);
-    EXPECT_TRUE(std::find(op1ConsumersAfter.begin(), op1ConsumersAfter.end(), 2) != op1ConsumersAfter.end());
-    EXPECT_TRUE(std::find(op1ConsumersAfter.begin(), op1ConsumersAfter.end(), 4) != op1ConsumersAfter.end());
+    ASSERT_EQ(op1ConsumersAfter.size(), 2);
+    EXPECT_EQ(op1ConsumersAfter[0], 2);
+    EXPECT_EQ(op1ConsumersAfter[1], 4);
 
     auto op2DepsAfter = info.getOpDeps(2);
-    EXPECT_EQ(op2DepsAfter.size(), 2);
-    EXPECT_TRUE(std::find(op2DepsAfter.begin(), op2DepsAfter.end(), 0) != op2DepsAfter.end());
-    EXPECT_TRUE(std::find(op2DepsAfter.begin(), op2DepsAfter.end(), 1) != op2DepsAfter.end());
+    ASSERT_EQ(op2DepsAfter.size(), 2);
+    EXPECT_EQ(op2DepsAfter[0], 0);
+    EXPECT_EQ(op2DepsAfter[1], 1);
 
     // Verify op0 consumers remain unchanged after adding op1->op2 dependency
     auto op0ConsumersAfter = info.getConsumerOps(0);
     EXPECT_EQ(op0ConsumersAfter.size(), 3);
+
+    // Rebuilding token operands consumes the cached, sorted dependency vectors.
+    // Exercise both the cache-miss and cache-hit paths and preserve deterministic order.
+    const auto verifyOp2Dependencies = [&]() {
+        auto op2Dependencies = info.getExecuteOpAtIndex(2).getDependencies();
+        ASSERT_EQ(op2Dependencies.size(), 2);
+        EXPECT_EQ(op2Dependencies[0], info.getExecuteOpAtIndex(0).getToken());
+        EXPECT_EQ(op2Dependencies[1], info.getExecuteOpAtIndex(1).getToken());
+    };
+    info.updateTokenDependencies();
+    verifyOp2Dependencies();
+    info.updateTokenDependencies();
+    verifyOp2Dependencies();
 }
 
 TEST_F(MLIR_AsyncDepsInfo, OptimizeDepsMap) {
@@ -222,10 +241,15 @@ TEST_F(MLIR_AsyncDepsInfo, OptimizeDepsMap) {
     ASSERT_TRUE(func != nullptr);
 
     vpux::AsyncDepsInfo info(func);
+    info.buildConsMap();
 
     // Before optimization: op2 depends on both op0 and op1
     auto op2DepsBefore = info.getOpDeps(2);
     EXPECT_EQ(op2DepsBefore.size(), 2);
+
+    // Prime the consumer cache before optimizeDepsMap rebuilds the consumer map.
+    auto op0ConsumersBefore = info.getConsumerOps(0);
+    EXPECT_EQ(op0ConsumersBefore.size(), 2);
 
     // Optimize: since op1 depends on op0, and op2 depends on both,
     // the dependency from op2 to op0 is redundant
@@ -235,6 +259,10 @@ TEST_F(MLIR_AsyncDepsInfo, OptimizeDepsMap) {
     auto op2DepsAfter = info.getOpDeps(2);
     EXPECT_EQ(op2DepsAfter.size(), 1);
     EXPECT_EQ(op2DepsAfter[0], 1);
+
+    auto op0ConsumersAfter = info.getConsumerOps(0);
+    EXPECT_EQ(op0ConsumersAfter.size(), 1);
+    EXPECT_EQ(op0ConsumersAfter[0], 1);
 }
 
 TEST_F(MLIR_AsyncDepsInfo, CalculateInOutDegree) {
@@ -314,26 +342,38 @@ TEST_F(MLIR_AsyncDepsInfo, InsertNewExecOp) {
     ASSERT_TRUE(func != nullptr);
 
     vpux::AsyncDepsInfo info(func);
+    info.buildConsMap();
+
+    // Prime both caches before extending the maps.
+    EXPECT_TRUE(info.getOpDeps(0).empty());
+    EXPECT_TRUE(info.getConsumerOps(0).empty());
 
     // Initial count should be 1
     EXPECT_EQ(info.getExecOpCount(), 1);
 
-    // Create a new async.execute operation
+    // Reserve a batch of slots to cover the production insertion pattern.
+    info.preAllocateForNewOps(2);
+
+    // Create new async.execute operations
     mlir::OpBuilder builder(&ctx);
-    builder.setInsertionPointToEnd(&func.getBody().front());
 
     auto memrefType = mlir::MemRefType::get({1, 32, 256, 256}, builder.getF16Type());
     auto asyncValueType = mlir::async::ValueType::get(memrefType);
     auto tokenType = builder.getType<mlir::async::TokenType>();
 
-    auto newExecOp =
-            builder.create<mlir::async::ExecuteOp>(builder.getUnknownLoc(), mlir::TypeRange{tokenType, asyncValueType},
-                                                   mlir::ValueRange{}, mlir::ValueRange{});
+    auto createExecOp = [&](mlir::ValueRange dependencies) {
+        builder.setInsertionPointToEnd(&func.getBody().front());
+        auto execOp = builder.create<mlir::async::ExecuteOp>(
+                builder.getUnknownLoc(), mlir::TypeRange{tokenType, asyncValueType}, dependencies, mlir::ValueRange{});
 
-    auto& bodyBlock = newExecOp.getBodyRegion().emplaceBlock();
-    builder.setInsertionPointToStart(&bodyBlock);
-    auto allocOp = builder.create<mlir::memref::AllocOp>(builder.getUnknownLoc(), memrefType);
-    builder.create<mlir::async::YieldOp>(builder.getUnknownLoc(), mlir::ValueRange{allocOp});
+        auto& bodyBlock = execOp.getBodyRegion().emplaceBlock();
+        builder.setInsertionPointToStart(&bodyBlock);
+        auto allocOp = builder.create<mlir::memref::AllocOp>(builder.getUnknownLoc(), memrefType);
+        builder.create<mlir::async::YieldOp>(builder.getUnknownLoc(), mlir::ValueRange{allocOp});
+        return execOp;
+    };
+
+    auto newExecOp = createExecOp(mlir::ValueRange{info.getExecuteOpAtIndex(0).getToken()});
 
     // Insert new exec op to deps map
     size_t newIdx = info.insertNewExecOpToDepsMap(newExecOp);
@@ -344,4 +384,41 @@ TEST_F(MLIR_AsyncDepsInfo, InsertNewExecOp) {
 
     auto retrievedOp = info.getExecuteOpAtIndex(newIdx);
     EXPECT_EQ(retrievedOp, newExecOp);
+
+    auto newOpDeps = info.getOpDeps(newIdx);
+    ASSERT_EQ(newOpDeps.size(), 1);
+    EXPECT_EQ(newOpDeps[0], 0);
+
+    auto op0Consumers = info.getConsumerOps(0);
+    ASSERT_EQ(op0Consumers.size(), 1);
+    EXPECT_EQ(op0Consumers[0], newIdx);
+
+    // Query between insertions so the second insertion must invalidate warm caches.
+    EXPECT_TRUE(info.getConsumerOps(newIdx).empty());
+
+    SmallVector<mlir::Value> secondOpDependencies{newExecOp.getToken(), info.getExecuteOpAtIndex(0).getToken()};
+    auto secondExecOp = createExecOp(secondOpDependencies);
+    auto secondIdx = info.insertNewExecOpToDepsMap(secondExecOp);
+
+    EXPECT_EQ(info.getExecOpCount(), 3);
+    EXPECT_EQ(secondIdx, 2);
+
+    auto secondOpDeps = info.getOpDeps(secondIdx);
+    ASSERT_EQ(secondOpDeps.size(), 2);
+    EXPECT_EQ(secondOpDeps[0], 0);
+    EXPECT_EQ(secondOpDeps[1], 1);
+
+    op0Consumers = info.getConsumerOps(0);
+    ASSERT_EQ(op0Consumers.size(), 2);
+    EXPECT_EQ(op0Consumers[0], 1);
+    EXPECT_EQ(op0Consumers[1], 2);
+
+    auto op1Consumers = info.getConsumerOps(1);
+    ASSERT_EQ(op1Consumers.size(), 1);
+    EXPECT_EQ(op1Consumers[0], 2);
+
+    // Repeat the final reads to exercise the cache-hit path.
+    EXPECT_EQ(info.getOpDeps(secondIdx), secondOpDeps);
+    EXPECT_EQ(info.getConsumerOps(0), op0Consumers);
+    EXPECT_EQ(info.getConsumerOps(1), op1Consumers);
 }


### PR DESCRIPTION
## Summary

`AsyncDepsInfo::getOpDeps()` and `getConsumerOps()` materialize and sort a `DenseSet` on every call. The feasible-allocation, prefetch, and scheduling paths query many stable dependency sets repeatedly, reconstructing and sorting the same vectors.

This change:

- lazily caches sorted dependency and consumer vectors;
- invalidates only entries whose underlying set changes;
- clears the relevant caches when dependency maps are optimized or consumer maps are rebuilt;
- routes initial dependency insertion through the same cache-invalidating path; and
- preserves the existing deterministic, sorted, by-value public API.

## Performance evidence

The previous validation campaign used Qwen2.5-7B INT8 on NPU.5010 with context windows 1024, 2048, 4096, and 8192. It alternated baseline/candidate ordering across three adjacent pairs per window, excluded warmups, and bypassed the UMD cache.

| Context window | Baseline median | Candidate median | Median paired improvement |
|---:|---:|---:|---:|
| 1024 | 351.715 s | 339.112 s | 3.583% |
| 2048 | 241.834 s | 232.774 s | 3.746% |
| 4096 | 253.098 s | 243.770 s | 3.678% |
| 8192 | 306.146 s | 297.526 s | 2.816% |

The candidate won all 12 pairs, with a 1.0359x geometric-mean speedup. A gated W2048 CPU profile measured:

- qsort-family CPU time: 7.960 s to 0.747 s (90.6% reduction);
- `FeasibleAllocation`: 18.471 s to 7.381 s (60.0% reduction); and
- full `compile_model`: 242.647 s to 234.255 s (3.46% improvement).

Those measurements predate the current `develop` base and are retained as historical evidence only.

### Current `develop` refresh

The final branch was benchmarked directly against `0b38f7d42113ff329ac2bdd33583d123de4ccf2f` with a version-matched OpenVINO 2026.4 C++ harness. The run used one excluded warm-up per arm/window, three adjacent pairs, balanced AB/BA ordering across windows, fresh processes, cold UMD cache, exact artifact hashes, and `/usr/bin/time -v` RSS.

| Window | Baseline median | Candidate median | Median wall improvement | Candidate wins | FeasibleAllocation improvement | Median RSS change |
|---:|---:|---:|---:|---:|---:|---:|
| 2048 | 244.907 s | 244.982 s | -0.031% | 1/3 | 2.255% | -0.483% |
| 1024 | 307.716 s | 309.224 s | -0.490% | 0/3 | 0.912% | +0.250% |

All six measured baseline/candidate pairs had identical 458-pass inventories and report counts. Across both windows, the candidate won 1/6 pairs; its geometric-mean improvement was -0.368%. The RSS gate passed, but the required 2% wall-time improvement did not.

A compile-interval diagnostic profile also did not reproduce the provisional 50% global qsort-family reduction. For one Qwen2.5-7B INT8 W2048 compile per arm at 49 Hz, baseline recorded 24 inclusive qsort-family samples (0.490 sampled CPU seconds) and the candidate recorded 34 (0.694 seconds), an observed reduction of -41.7%. Total sampled CPU and compile wall time were effectively unchanged, pass inventories matched exactly, and compiler-reported `FeasibleAllocation` time improved by 1.88%. Because this is a low-count, fixed-order, global attribution from stripped binaries, it does not isolate `AsyncDepsInfo` or establish a regression; it shows that the historical global-qsort gate was not met on current `develop`.

The current evidence therefore does not justify promoting this draft for review. A redesign should begin with targeted cache hit/miss, invalidation, and sort-call instrumentation; repeat AB/BA profiles with symbolization before spending the larger model-matrix budget.

## Correctness and validation

Validated on NUC16 from final commit `fce7e0e737e3370b9067fa3adecc201753540aed`, based directly on `develop` at `0b38f7d42113ff329ac2bdd33583d123de4ccf2f`:

- [x] clang-format 18.1.8 and `git diff --check`: passed.
- [x] Focused `MLIR_AsyncDepsInfo.*`: 5/5 passed.
- [x] Complete `npuUnitTests`: 7,085/7,085 enabled tests passed; 31 disabled.
- [x] All-platform LIT validation completed with exit status 0 for every invocation:

  | Platform | Passed | Expected failures (XFAIL) | Unsupported | Total |
  |---|---:|---:|---:|---:|
  | NPU3720 | 967 | 3 | 682 | 1,652 |
  | NPU4000 | 1,225 | 4 | 423 | 1,652 |
  | NPU5010 | 1,237 | 7 | 408 | 1,652 |
  | NPU5020 | 9 | 0 | 1,643 | 1,652 |

  `UNSUPPORTED` is the expected per-platform filtering of the shared corpus; there were no unexpected failures, unresolved tests, timeouts, or unexpected passes.
- [x] `ov_npu_unit_tests`: 1,500 total; 1,463 passed and 37 hardware-dependent tests skipped.
- [x] Qwen2.5-7B INT8 W2048 PLUGIN real-model correctness smoke: version-matched OpenVINO 2026.4 C++ baseline and candidate compiles both succeeded, each loading exactly its intended compiler artifact. Baseline wall time was 244.495 s; candidate wall time was 245.818 s. These excluded warm-ups are a correctness gate, not performance evidence.
- [x] Paired current-upstream performance and peak-RSS campaign completed with exact pass-inventory agreement and acceptable RSS, but the wall-time acceptance gate was not met. The excluded smoke timings above are not performance evidence.
- [x] Transient fresh-sort cache-coherence oracle: recomputed and compared the sorted dependency/consumer vector on every lookup; 50 focused test executions, all 7,085 enabled unit tests, and a Qwen2.5-7B W2048 compile passed without a stale-cache finding. The source, unit test, compiler, and runtime compiler were restored to their exact pre-run hashes.
- [x] Targeted current-base qsort CPU profile completed with exact compiler/runtime provenance and pass-inventory agreement. The broad global-qsort gate was not met; feature-specific attribution remains inconclusive without symbols or targeted counters.

### GitHub-hosted checks awaiting repository approval

The following workflows currently report `action_required` for the final SHA and remain unchecked until they are approved and complete:

- [ ] Linux (Ubuntu 22.04) workflow.
- [ ] Linux (Ubuntu 24.04) build/test workflow.
- [ ] PLUGIN and DRIVER compilation matrices for NPU.3720, NPU.4000, NPU.5010, and NPU.5020.
- [ ] Windows (2022) workflow.
- [ ] `clang-format` workflow (the manual formatting check above has passed).
- [ ] Scorecard supply-chain security workflow.

## Expanded profiling plan

The work is split into a bounded merge gate and a broader scale study so that the PR is not justified by one model family:

1. **Current-base merge gate:** Qwen2.5-7B INT8 at W1024 and W2048 is complete and did not meet the wall-time or global-qsort gates. Before proceeding, add cache hit/miss, invalidation, and sort-call counters; repeat symbolized AB/BA profiles. Only if those identify a material feature-specific hotspot, add Qwen2.5-0.5B W128 and ResNet-18 INT8 at 224 as small negative controls.
2. **Required compiler compatibility matrix:** the repository's 156 public-model configurations in both PLUGIN and DRIVER modes across NPU.3720, NPU.4000, NPU.5010, and NPU.5020. Existing families include MobileNetV2, ResNet-50, YOLOv4, BERT, ViT, CLIP, and SAM components.
3. **Synthetic scale controls:** dependency DAGs with 128, 1K, 5K, 10K, and 25K async operations at fan-in 2, 8, and 32. Measure construction, cold reads, 100 hot sweeps, 1% mutation plus touched-entry reads, consumer rebuild, and dependency optimization; assert fresh-sort equality after every phase.
4. **Installed-model scale study:** Qwen2.5 INT8/FP16 at 0.5B, 1.5B, 3B, and 7B; Llama-3.2 INT8/FP16 at 1B and 3B; ResNet-18/34/50/101/152 across 128-640 resolutions; MobileNetV3, EfficientNet-B0, DenseNet-121, RegNetY-040, Inception-v3, ConvNeXt-Tiny, and ViT Base/Large. Screen the 115 currently registered model/shape cells with three pairs, then promote representative improvements, neutral cases, and regressions to five-pair runs.
5. **Future architecture coverage:** stage TinyLlama, Phi-3 Mini, Gemma-2, Mistral, Qwen2.5-14B, and MoE models only after a separate storage/export preflight; these are follow-up coverage rather than a merge gate.
6. **Measurement method:** identical Release builds and dependency pins; one fresh process per compile; cold UMD cache; recorded compiler/runtime/model hashes; paired wall time with read time kept separate; and `/usr/bin/time -v` RSS. Keep `perf stat`, compile-interval `perf record`, pass timing, qsort samples, async vertices/edges, degree, cache hit/miss, invalidation, allocation, and retained-capacity counters in separate diagnostic runs so instrumentation cannot perturb the wall-time samples.
7. **Acceptance gate:** dependency and consumer order matches a diagnostic fresh-sort oracle on every lookup and compilation succeeds; at least 50% less qsort-family CPU time and at least 2% lower median `compile_model` wall time on both high-task graphs; no median regression above 3% on either small control; no median peak-RSS growth at or above 5% on the largest graph; and explicit reporting of the O(V + E) cache-memory cost. Blob hashes are recorded for provenance, not compared as a correctness gate, because repeated identical compiler runs are not bit-deterministic.

## Memory tradeoff

The cache retains sorted vectors alongside the dependency sets, adding O(V + E) storage plus per-entry optional/vector overhead. On the current-base paired run, median maximum RSS changed by -0.483% at W2048 and +0.250% at W1024; the worst paired increase was 2.063%, within the 5% gate.

## JIRA ticket

Fixes #342

## Target Platform For Release Notes

- [x] NPU37XX
- [x] NPU40XX
- [x] NPU50XX
- [ ] NONE (Not included in release notes)

The implementation is architecture-independent. Hardware performance profiling is performed on NPU.5010; the CI compilation and LIT matrices cover all supported architecture families.

## Classification of this Pull Request

- [x] Maintenance
- [ ] BUG
- [ ] Feature

## AI Assistance

- AI assistance used: yes
- If yes: repository and checklist review, test planning, and editing suggestions.
- Human validation performed: contributor code review is complete; formatting, focused and full unit tests, all-platform LIT, OpenVINO NPU unit tests, version-matched real-model smoke compiles, the paired current-base campaign, the fresh-sort oracle, and the targeted current-base profile completed on the current head. Correctness passed, but the wall-time and broad global-qsort acceptance gates were not met. Repository CI and maintainer review remain pending while the draft is performance-blocked.
